### PR TITLE
feat: android ANR detection

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -46,6 +46,10 @@ jobs:
 
     # Build with Gradle using the Android SDK's CMake
     - name: Build with Gradle
+      env:
+        # The example module requires a bugsplat.database value to configure.
+        # CI doesn't upload symbols, so a placeholder is fine.
+        BUGSPLAT_DATABASE: fred
       run: ./gradlew assembleDebug --no-daemon
 
     - name: Perform CodeQL Analysis

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,28 @@
+name: Tests
+
+on:
+  pull_request:
+    branches: [ "main", "master" ]
+
+jobs:
+  unit-tests:
+    name: Unit Tests
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Set up JDK 17
+      uses: actions/setup-java@v4
+      with:
+        java-version: '17'
+        distribution: 'temurin'
+
+    - name: Install Android SDK CMake
+      run: |
+        echo "y" | $ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager "cmake;3.22.1"
+        echo "$ANDROID_HOME/cmake/3.22.1/bin" >> $GITHUB_PATH
+
+    - name: Run unit tests
+      run: ./gradlew :app:testDebugUnitTest --no-daemon

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,4 +25,8 @@ jobs:
         echo "$ANDROID_HOME/cmake/3.22.1/bin" >> $GITHUB_PATH
 
     - name: Run unit tests
+      env:
+        # The example module requires a bugsplat.database value to configure.
+        # CI doesn't upload symbols, so a placeholder is fine.
+        BUGSPLAT_DATABASE: fred
       run: ./gradlew :app:testDebugUnitTest --no-daemon

--- a/README.md
+++ b/README.md
@@ -173,68 +173,56 @@ This approach requires the `symbol-upload` executable to be included in your app
 
 #### 2. Using Gradle Build Tasks
 
-You can also add a Gradle task to your build process to automatically upload symbols when you build your app. Here's an example of how to set this up:
+You can wire symbol upload into your Gradle build so it runs automatically after `assembleDebug` / `assembleRelease`. The recommended pattern is to keep credentials out of `build.gradle` by loading them from the gitignored `local.properties`.
+
+**Step 1 — Add credentials to `local.properties` (do not commit):**
+
+```properties
+bugsplat.database=your_database
+bugsplat.clientId=your_client_id
+bugsplat.clientSecret=your_client_secret
+```
+
+**Step 2 — Load them in `build.gradle` and register per-ABI upload tasks:**
 
 ```gradle
-// BugSplat configuration
+// Load BugSplat credentials from local.properties
+def localProps = new Properties()
+def localPropsFile = rootProject.file('local.properties')
+if (localPropsFile.exists()) {
+    localPropsFile.withInputStream { localProps.load(it) }
+}
+
 ext {
-    bugsplatDatabase = "your_database_name" // Replace with your BugSplat database name
-    bugsplatAppName = "your_app_name"       // Replace with your application name
+    bugsplatDatabase = localProps.getProperty('bugsplat.database')
+    bugsplatClientId = localProps.getProperty('bugsplat.clientId', '')
+    bugsplatClientSecret = localProps.getProperty('bugsplat.clientSecret', '')
+    // Use applicationId and versionName as the single source of truth
+    bugsplatAppName = android.defaultConfig.applicationId
     bugsplatAppVersion = android.defaultConfig.versionName
-    // Optional: Add your BugSplat API credentials for symbol upload
-    bugsplatClientId = ""     // Replace with your BugSplat API client ID (optional)
-    bugsplatClientSecret = "" // Replace with your BugSplat API client secret (optional)
 }
 
-// Task to upload debug symbols for native libraries
-task uploadBugSplatSymbols {
-    doLast {
-        // Path to the merged native libraries
-        def nativeLibsDir = "${buildDir}/intermediates/merged_native_libs/debug/out/lib"
-        
-        // Check if the directory exists
-        def nativeLibsDirFile = file(nativeLibsDir)
-        if (!nativeLibsDirFile.exists()) {
-            logger.warn("Native libraries directory not found: ${nativeLibsDir}")
-            return
-        }
-        
-        // Path to the symbol-upload executable
-        def symbolUploadPath = "path/to/symbol-upload" // Adjust this path
-        
-        // Build the command with the directory and glob pattern
-        def command = [
-            symbolUploadPath,
-            "-b", project.ext.bugsplatDatabase,
-            "-a", project.ext.bugsplatAppName,
-            "-v", project.ext.bugsplatAppVersion,
-            "-d", nativeLibsDirFile.absolutePath,
-            "-f", "**/*.so",
-            "-m"  // Run dumpsyms
-        ]
-        
-        // Add client credentials if provided
-        if (project.ext.has('bugsplatClientId') && project.ext.bugsplatClientId) {
-            command.add("-i")
-            command.add(project.ext.bugsplatClientId)
-            command.add("-s")
-            command.add(project.ext.bugsplatClientSecret)
-        }
-        
-        // Execute the command
-        // ... (see example app for full implementation)
-    }
-}
+// See example/build.gradle for the full implementation including:
+//   - resolveSymbolUploadExecutable()   - downloads the symbol-upload binary
+//   - uploadSymbolsForAbi(buildType, abi) - runs symbol-upload against
+//     build/intermediates/merged_native_libs/<buildType>/merge<BuildType>NativeLibs/out/lib/<abi>/
+//   - Per-ABI tasks (uploadBugSplatSymbolsDebugArm64-v8a, etc.)
+//   - AllAbis task that chains the per-ABI tasks serially via mustRunAfter
+//     (parallel uploads aren't safe — the symbol-upload binary uses a shared temp dir)
 
-// Run the symbol upload task after the assembleDebug task
+// Run symbol upload after assembleDebug
 tasks.whenTaskAdded { task ->
     if (task.name == 'assembleDebug') {
-        task.finalizedBy(uploadBugSplatSymbols)
+        task.finalizedBy(tasks.named('uploadBugSplatSymbolsDebugAllAbis'))
     }
 }
 ```
 
-See the [Example App README](example/README.md) for a complete implementation of this approach.
+See [`example/build.gradle`](example/build.gradle) for the complete, working implementation. Key details:
+
+- **Intermediate path** — AGP 8.6+ places merged native libs at `merged_native_libs/<buildType>/merge<BuildType>NativeLibs/out/lib/<abi>/`. Older AGPs used a flat `merged_native_libs/<buildType>/out/lib/<abi>/` layout.
+- **Serial execution** — the `symbol-upload` binary uses a shared temp directory, so per-ABI uploads must be chained via `mustRunAfter` rather than running in parallel.
+- **Missing ABIs** — when Android Studio runs on a single-ABI device (e.g. an arm64 emulator), only that ABI's libs get built. Per-ABI tasks for other ABIs will log a warning and skip cleanly.
 
 #### 3. Using the Command-Line Tool
 

--- a/README.md
+++ b/README.md
@@ -327,6 +327,40 @@ When integrating BugSplat into your Android application, it's crucial to ensure 
 
 These configurations ensure that the BugSplat native libraries are properly included in your app and can function correctly to capture and report native crashes.
 
+## ANR Detection 🐌
+
+The BugSplat Android SDK automatically detects and reports Application Not Responding (ANR) events on Android 11+ (API level 30+) using the [`ApplicationExitInfo`](https://developer.android.com/reference/android/app/ApplicationExitInfo) API.
+
+### How It Works
+
+When the system kills your app due to an ANR, the event is recorded by Android. On the next app launch, the SDK queries `ActivityManager.getHistoricalProcessExitReasons()` for new ANRs, reads the system-provided thread dump, and uploads it to BugSplat. ANR reports appear alongside crashes with the **"Android ANR"** type.
+
+The thread dump includes:
+- Full Java stack traces for all threads in the process
+- Native stack frames with BuildIds (symbolicated against uploaded `.sym` files)
+- Lock contention information (which threads are holding/waiting for locks)
+
+### Configuration
+
+ANR detection is enabled automatically when you call `BugSplat.init()` — no additional configuration needed. The SDK persists the timestamp of the last reported ANR in `SharedPreferences` to avoid duplicate uploads across launches.
+
+### Testing ANR Detection
+
+To test ANR detection, use `BugSplat.hang()` to block the main thread in a native infinite loop:
+
+```java
+// Call this on the main thread to trigger an ANR
+BugSplat.hang();
+```
+
+After calling `BugSplat.hang()`, tap the screen to generate a pending input event — the system will show an ANR dialog after ~5 seconds. Choose "Close app" to kill the process. On the next app launch, the SDK will upload the ANR report to BugSplat.
+
+The resulting thread dump includes a native frame for `jniHang`, which demonstrates end-to-end symbolication when your `.sym` files have been uploaded.
+
+### Supported Versions
+
+ANR detection requires **Android 11+ (API 30+)**. On older Android versions, the `ApplicationExitInfo` API is unavailable and ANR detection is silently disabled.
+
 ## User Feedback 💬
 
 BugSplat supports collecting non-crashing user feedback such as bug reports and feature requests. Feedback reports appear in BugSplat alongside crash reports with the "User Feedback" type.
@@ -392,7 +426,9 @@ To run the example app:
 The example app demonstrates:
 - Automatically initializing the BugSplat SDK at app startup
 - Triggering a crash for testing purposes
+- Triggering an ANR (via `BugSplat.hang()`) to test ANR detection and native frame symbolication
 - Submitting user feedback via a dialog
+- Setting custom attributes via a dialog
 - Handling errors during initialization
 
 For more information, see the [Example App README](example/README.md).

--- a/README.md
+++ b/README.md
@@ -102,15 +102,65 @@ After completing these steps, you can start using BugSplat in your Android appli
 
 ### Configuration
 
-To configure BugSplat to handle native crashes, simply call `initBugSplat` with the desired arguments. Be sure that the value you provide for `database` matches the value in the BugSplat web app.
+To configure BugSplat to handle native crashes, simply call `BugSplat.init` with the desired arguments. Be sure that the value you provide for `database` matches the value in the BugSplat web app.
 
 ```kotlin
-BugSplatBridge.initBugSplat(this, database, application, version)
+BugSplat.init(this, database, application, version)
 ```
 
-You can also add file attributes, and/or file attachments to your crash reports.
+### Loading config from local.properties (recommended)
 
-Kotlin
+Keeping your database name, app name, and version in one place avoids drift between runtime (`BugSplat.init`) and symbol upload. The pattern most BugSplat users adopt:
+
+1. Add the database name to the gitignored `local.properties`:
+
+   ```properties
+   bugsplat.database=your_database
+   ```
+
+2. In your app module's `build.gradle`, load it and expose it (plus `applicationId` and `versionName`) as `BuildConfig` fields:
+
+   ```gradle
+   def localProps = new Properties()
+   def localPropsFile = rootProject.file('local.properties')
+   if (localPropsFile.exists()) {
+       localPropsFile.withInputStream { localProps.load(it) }
+   }
+
+   android {
+       defaultConfig {
+           applicationId "com.example.myapp"
+           versionName "1.0.0"
+
+           buildConfigField "String", "BUGSPLAT_DATABASE",
+               "\"${localProps.getProperty('bugsplat.database')}\""
+           buildConfigField "String", "BUGSPLAT_APP_NAME",
+               "\"${applicationId}\""
+           buildConfigField "String", "BUGSPLAT_APP_VERSION",
+               "\"${versionName}\""
+       }
+       buildFeatures { buildConfig true }
+   }
+   ```
+
+3. Initialize BugSplat from the generated `BuildConfig`:
+
+   ```java
+   BugSplat.init(
+       this,
+       BuildConfig.BUGSPLAT_DATABASE,
+       BuildConfig.BUGSPLAT_APP_NAME,
+       BuildConfig.BUGSPLAT_APP_VERSION
+   );
+   ```
+
+See [`example/build.gradle`](example/build.gradle) for the complete working setup. This same `bugsplat.database` value is also picked up by the symbol upload task, so there's a single source of truth across the whole build.
+
+### Attributes and attachments
+
+You can also add custom attributes and/or file attachments to your crash reports.
+
+**Kotlin**
 ```kotlin
 val attributes = mapOf(
     "key1" to "value1",
@@ -118,27 +168,36 @@ val attributes = mapOf(
     "environment" to "development"
 )
 
-val attachmentFileName = "log.txt"
-createAttachmentFile(attachmentFileName)
-val attachmentPath = applicationContext.getFileStreamPath(attachmentFileName).absolutePath
+val attachmentPath = applicationContext.getFileStreamPath("log.txt").absolutePath
 val attachments = arrayOf(attachmentPath)
 
-BugSplatBridge.initBugSplat(this, "fred", "my-android-crasher", "2.0.0", attributes, attachments)
+BugSplat.init(
+    this,
+    BuildConfig.BUGSPLAT_DATABASE,
+    BuildConfig.BUGSPLAT_APP_NAME,
+    BuildConfig.BUGSPLAT_APP_VERSION,
+    attributes,
+    attachments
+)
 ```
 
-Java
+**Java**
 ```java
 Map<String, String> attributes = new HashMap<>();
 attributes.put("key1", "value1");
-attributes.put("key2", "value2");
 attributes.put("environment", "development");
 
-String attachmentFileName = "log.txt";
-createAttachmentFile(attachmentFileName);
-String attachmentPath = getApplicationContext().getFileStreamPath(attachmentFileName).getAbsolutePath();
+String attachmentPath = getApplicationContext().getFileStreamPath("log.txt").getAbsolutePath();
 String[] attachments = new String[]{attachmentPath};
 
-BugSplatBridge.initBugSplat(this, "fred", "my-android-crasher", "2.0.0", attributes, attachments);
+BugSplat.init(
+    this,
+    BuildConfig.BUGSPLAT_DATABASE,
+    BuildConfig.BUGSPLAT_APP_NAME,
+    BuildConfig.BUGSPLAT_APP_VERSION,
+    attributes,
+    attachments
+);
 ```
 
 ### Symbol Upload
@@ -355,14 +414,14 @@ BugSplat supports collecting non-crashing user feedback such as bug reports and 
 
 ### Posting Feedback
 
-Use `BugSplat.postFeedback` to submit feedback asynchronously, or `BugSplat.postFeedbackBlocking` for synchronous submission:
+Use `BugSplat.postFeedback` to submit feedback asynchronously, or `BugSplat.postFeedbackBlocking` for synchronous submission. The `database`, `application`, and `version` values are typically loaded from `BuildConfig` (see [Loading config from local.properties](#loading-config-from-localproperties-recommended)):
 
 ```java
 // Async (returns immediately, runs on background thread)
 BugSplat.postFeedback(
-    "fred",                    // database
-    "my-android-crasher",      // application
-    "1.0.0",                   // version
+    BuildConfig.BUGSPLAT_DATABASE,
+    BuildConfig.BUGSPLAT_APP_NAME,
+    BuildConfig.BUGSPLAT_APP_VERSION,
     "Login button broken",     // title (required)
     "Nothing happens on tap",  // description
     "Jane",                    // user
@@ -372,7 +431,9 @@ BugSplat.postFeedback(
 
 // Blocking (returns true on success)
 boolean success = BugSplat.postFeedbackBlocking(
-    "fred", "my-android-crasher", "1.0.0",
+    BuildConfig.BUGSPLAT_DATABASE,
+    BuildConfig.BUGSPLAT_APP_NAME,
+    BuildConfig.BUGSPLAT_APP_VERSION,
     "Login button broken", "Nothing happens on tap",
     "Jane", "jane@example.com", null
 );
@@ -388,10 +449,32 @@ attachments.add(new File(getFilesDir(), "screenshot.png"));
 attachments.add(new File(getFilesDir(), "app.log"));
 
 BugSplat.postFeedback(
-    "fred", "my-android-crasher", "1.0.0",
+    BuildConfig.BUGSPLAT_DATABASE,
+    BuildConfig.BUGSPLAT_APP_NAME,
+    BuildConfig.BUGSPLAT_APP_VERSION,
     "Login button broken", "Nothing happens on tap",
     "Jane", "jane@example.com", null,
     attachments
+);
+```
+
+### Custom Attributes
+
+Attach arbitrary key/value metadata to feedback reports:
+
+```java
+Map<String, String> attributes = new HashMap<>();
+attributes.put("environment", "production");
+attributes.put("user_tier", "premium");
+
+BugSplat.postFeedback(
+    BuildConfig.BUGSPLAT_DATABASE,
+    BuildConfig.BUGSPLAT_APP_NAME,
+    BuildConfig.BUGSPLAT_APP_VERSION,
+    "Login button broken", "Nothing happens on tap",
+    "Jane", "jane@example.com", null,
+    null,        // attachments
+    attributes
 );
 ```
 

--- a/README.md
+++ b/README.md
@@ -321,7 +321,7 @@ The BugSplat Android SDK automatically detects and reports Application Not Respo
 
 ### How It Works
 
-When the system kills your app due to an ANR, the event is recorded by Android. On the next app launch, the SDK queries `ActivityManager.getHistoricalProcessExitReasons()` for new ANRs, reads the system-provided thread dump, and uploads it to BugSplat. ANR reports appear alongside crashes with the **"Android ANR"** type.
+When the system kills your app due to an ANR, the event is recorded by Android. On the next app launch, the SDK queries `ActivityManager.getHistoricalProcessExitReasons()` for new ANRs, reads the system-provided thread dump, and uploads it to BugSplat. ANR reports appear alongside crashes with the **"Android.ANR"** type.
 
 The thread dump includes:
 - Full Java stack traces for all threads in the process

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -47,6 +47,10 @@ android {
         }
     }
 
+    testOptions {
+        unitTests.returnDefaultValues = true
+    }
+
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
@@ -113,6 +117,8 @@ dependencies {
     implementation libs.material
     implementation libs.androidx.constraintlayout
     testImplementation libs.junit
+    testImplementation libs.mockwebserver
+    testImplementation 'org.json:json:20231013'
     androidTestImplementation libs.androidx.junit
     androidTestImplementation libs.androidx.espresso.core
 }

--- a/app/src/main/cpp/native-lib.cpp
+++ b/app/src/main/cpp/native-lib.cpp
@@ -57,6 +57,9 @@ extern "C" JNIEXPORT void JNICALL
 Java_com_bugsplat_android_BugSplatBridge_jniCrash(JNIEnv *env, jclass clazz);
 
 extern "C" JNIEXPORT void JNICALL
+Java_com_bugsplat_android_BugSplatBridge_jniHang(JNIEnv *env, jclass clazz);
+
+extern "C" JNIEXPORT void JNICALL
 Java_com_bugsplat_android_BugSplatBridge_jniSetAttribute(JNIEnv *env, jclass clazz,
                                                          jstring key, jstring value);
 
@@ -144,6 +147,15 @@ Java_com_bugsplat_android_BugSplatBridge_jniCrash(JNIEnv *env, jclass clazz)
 {
     volatile int* a = reinterpret_cast<volatile int*>(0x42);
     *a = 1;
+}
+
+extern "C" JNIEXPORT void JNICALL
+Java_com_bugsplat_android_BugSplatBridge_jniHang(JNIEnv *env, jclass clazz)
+{
+    volatile int counter = 0;
+    while (true) {
+        counter++;
+    }
 }
 
 // Utility function implementations

--- a/app/src/main/java/com/bugsplat/android/AnrReporter.java
+++ b/app/src/main/java/com/bugsplat/android/AnrReporter.java
@@ -10,6 +10,7 @@ import android.util.Log;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -136,12 +137,13 @@ class AnrReporter {
 
             boolean uploaded = false;
             try {
-                uploaded = uploader.upload(
-                        threadDump.getBytes("UTF-8"),
+                byte[] zipped = ReportUploader.zip(
                         "anr_trace.txt",
-                        CRASH_TYPE,
-                        CRASH_TYPE_ID
-                );
+                        threadDump.getBytes(StandardCharsets.UTF_8));
+                CommitOptions options = new CommitOptions()
+                        .crashType(CRASH_TYPE)
+                        .crashTypeId(CRASH_TYPE_ID);
+                uploaded = uploader.upload(zipped, options);
             } catch (IOException e) {
                 Log.e(TAG, "Failed to upload ANR report", e);
             }
@@ -177,7 +179,7 @@ class AnrReporter {
             while ((bytesRead = is.read(buffer)) != -1) {
                 baos.write(buffer, 0, bytesRead);
             }
-            return baos.toString("UTF-8");
+            return new String(baos.toByteArray(), StandardCharsets.UTF_8);
         } catch (IOException e) {
             Log.e(TAG, "Failed to read ANR trace stream", e);
             return null;

--- a/app/src/main/java/com/bugsplat/android/AnrReporter.java
+++ b/app/src/main/java/com/bugsplat/android/AnrReporter.java
@@ -10,6 +10,8 @@ import android.util.Log;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -66,6 +68,10 @@ class AnrReporter {
                 Log.e(TAG, "Failed to check/report ANRs", e);
             }
         });
+        // This reporter is one-shot — there will never be more work submitted
+        // after the initial check. shutdown() lets the worker thread exit once
+        // the submitted task completes instead of lingering as a daemon.
+        executor.shutdown();
     }
 
     private void checkAndReportInternal() {
@@ -89,25 +95,34 @@ class AnrReporter {
 
         SharedPreferences prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE);
         long lastReportedTimestamp = prefs.getLong(PREF_LAST_REPORTED_TIMESTAMP, 0);
-        long newestAnrTimestamp = lastReportedTimestamp;
+
+        // getHistoricalProcessExitReasons returns newest-first. Reverse to
+        // oldest-first so we can advance the watermark in chronological order
+        // and stop on the first upload failure (leaving newer ANRs for the
+        // next launch). This prevents a successful newer upload from masking
+        // a failed older one.
+        List<ApplicationExitInfo> orderedOldestFirst = new ArrayList<>(exitInfos);
+        Collections.reverse(orderedOldestFirst);
 
         ReportUploader uploader = new ReportUploader(database, application, version);
+        long advanceTo = lastReportedTimestamp;
 
-        for (ApplicationExitInfo exitInfo : exitInfos) {
+        for (ApplicationExitInfo exitInfo : orderedOldestFirst) {
             if (exitInfo.getReason() != ApplicationExitInfo.REASON_ANR) {
                 continue;
             }
 
             long timestamp = exitInfo.getTimestamp();
             if (timestamp <= lastReportedTimestamp) {
-                break;
+                continue; // already reported in a prior session
             }
-
-            newestAnrTimestamp = Math.max(newestAnrTimestamp, timestamp);
 
             String threadDump = readTraceStream(exitInfo);
             if (threadDump == null || threadDump.isEmpty()) {
-                Log.w(TAG, "Empty trace stream for ANR at " + timestamp);
+                // Some ANR records have no trace (known Android quirk).
+                // Advance past them so we don't retry forever.
+                Log.w(TAG, "Empty trace stream for ANR at " + timestamp + ", skipping");
+                advanceTo = Math.max(advanceTo, timestamp);
                 continue;
             }
 
@@ -119,8 +134,9 @@ class AnrReporter {
                     + ", foreground=" + foreground
                     + ", description=" + exitInfo.getDescription() + ")");
 
+            boolean uploaded = false;
             try {
-                uploader.upload(
+                uploaded = uploader.upload(
                         threadDump.getBytes("UTF-8"),
                         "anr_trace.txt",
                         CRASH_TYPE,
@@ -129,11 +145,19 @@ class AnrReporter {
             } catch (IOException e) {
                 Log.e(TAG, "Failed to upload ANR report", e);
             }
+
+            if (uploaded) {
+                advanceTo = Math.max(advanceTo, timestamp);
+            } else {
+                // Transient failure — stop so the remaining newer ANRs
+                // are retried next launch.
+                break;
+            }
         }
 
-        if (newestAnrTimestamp > lastReportedTimestamp) {
+        if (advanceTo > lastReportedTimestamp) {
             prefs.edit()
-                    .putLong(PREF_LAST_REPORTED_TIMESTAMP, newestAnrTimestamp)
+                    .putLong(PREF_LAST_REPORTED_TIMESTAMP, advanceTo)
                     .apply();
         }
     }

--- a/app/src/main/java/com/bugsplat/android/AnrReporter.java
+++ b/app/src/main/java/com/bugsplat/android/AnrReporter.java
@@ -34,7 +34,7 @@ class AnrReporter {
     private static final String TAG = "BugSplat-ANR";
     private static final String PREFS_NAME = "bugsplat_anr";
     private static final String PREF_LAST_REPORTED_TIMESTAMP = "last_reported_anr_timestamp";
-    private static final String CRASH_TYPE = "Android ANR";
+    private static final String CRASH_TYPE = "Android.ANR";
     private static final int CRASH_TYPE_ID = 37;
 
     private final Context context;

--- a/app/src/main/java/com/bugsplat/android/AnrReporter.java
+++ b/app/src/main/java/com/bugsplat/android/AnrReporter.java
@@ -1,0 +1,162 @@
+package com.bugsplat.android;
+
+import android.app.ActivityManager;
+import android.app.ApplicationExitInfo;
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.os.Build;
+import android.util.Log;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+/**
+ * Detects and reports ANR (Application Not Responding) events using the
+ * ApplicationExitInfo API available on Android 11+ (API 30+).
+ *
+ * On each SDK initialization, this class checks for historical ANR exit reasons
+ * from previous process instances. For each new (unreported) ANR, it reads the
+ * system-provided thread dump and uploads it to BugSplat via the 3-part S3 upload.
+ *
+ * The thread dump is plain text in the same format as /data/anr/traces.txt and
+ * includes all threads with full Java + native stack traces, lock info, and
+ * BuildIds for native frames. Native frame addresses are relative to the library
+ * load address and can be symbolicated against .sym files by matching FUNC/line
+ * records.
+ */
+class AnrReporter {
+    private static final String TAG = "BugSplat-ANR";
+    private static final String PREFS_NAME = "bugsplat_anr";
+    private static final String PREF_LAST_REPORTED_TIMESTAMP = "last_reported_anr_timestamp";
+    private static final String CRASH_TYPE = "Android ANR";
+    private static final int CRASH_TYPE_ID = 37;
+
+    private final Context context;
+    private final String database;
+    private final String application;
+    private final String version;
+    private final ExecutorService executor;
+
+    AnrReporter(Context context, String database, String application, String version) {
+        this.context = context.getApplicationContext();
+        this.database = database;
+        this.application = application;
+        this.version = version;
+        this.executor = Executors.newSingleThreadExecutor();
+    }
+
+    /**
+     * Check for unreported ANRs and upload them in the background.
+     * Safe to call on any API level — silently no-ops below Android 11.
+     */
+    void checkAndReport() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R) {
+            Log.d(TAG, "ANR reporting requires Android 11+ (API 30+), skipping");
+            return;
+        }
+
+        executor.execute(() -> {
+            try {
+                checkAndReportInternal();
+            } catch (Exception e) {
+                Log.e(TAG, "Failed to check/report ANRs", e);
+            }
+        });
+    }
+
+    private void checkAndReportInternal() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R) {
+            return;
+        }
+
+        ActivityManager am = (ActivityManager) context.getSystemService(Context.ACTIVITY_SERVICE);
+        if (am == null) {
+            Log.w(TAG, "ActivityManager unavailable");
+            return;
+        }
+
+        List<ApplicationExitInfo> exitInfos = am.getHistoricalProcessExitReasons(
+                context.getPackageName(), 0, 0);
+
+        if (exitInfos == null || exitInfos.isEmpty()) {
+            Log.d(TAG, "No historical exit reasons found");
+            return;
+        }
+
+        SharedPreferences prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE);
+        long lastReportedTimestamp = prefs.getLong(PREF_LAST_REPORTED_TIMESTAMP, 0);
+        long newestAnrTimestamp = lastReportedTimestamp;
+
+        ReportUploader uploader = new ReportUploader(database, application, version);
+
+        for (ApplicationExitInfo exitInfo : exitInfos) {
+            if (exitInfo.getReason() != ApplicationExitInfo.REASON_ANR) {
+                continue;
+            }
+
+            long timestamp = exitInfo.getTimestamp();
+            if (timestamp <= lastReportedTimestamp) {
+                break;
+            }
+
+            newestAnrTimestamp = Math.max(newestAnrTimestamp, timestamp);
+
+            String threadDump = readTraceStream(exitInfo);
+            if (threadDump == null || threadDump.isEmpty()) {
+                Log.w(TAG, "Empty trace stream for ANR at " + timestamp);
+                continue;
+            }
+
+            boolean foreground = exitInfo.getImportance()
+                    == ActivityManager.RunningAppProcessInfo.IMPORTANCE_FOREGROUND;
+
+            Log.i(TAG, "Reporting ANR at " + timestamp
+                    + " (pid=" + exitInfo.getPid()
+                    + ", foreground=" + foreground
+                    + ", description=" + exitInfo.getDescription() + ")");
+
+            try {
+                uploader.upload(
+                        threadDump.getBytes("UTF-8"),
+                        "anr_trace.txt",
+                        CRASH_TYPE,
+                        CRASH_TYPE_ID
+                );
+            } catch (IOException e) {
+                Log.e(TAG, "Failed to upload ANR report", e);
+            }
+        }
+
+        if (newestAnrTimestamp > lastReportedTimestamp) {
+            prefs.edit()
+                    .putLong(PREF_LAST_REPORTED_TIMESTAMP, newestAnrTimestamp)
+                    .apply();
+        }
+    }
+
+    private String readTraceStream(ApplicationExitInfo exitInfo) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R) {
+            return null;
+        }
+
+        try (InputStream is = exitInfo.getTraceInputStream()) {
+            if (is == null) {
+                return null;
+            }
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            byte[] buffer = new byte[4096];
+            int bytesRead;
+            while ((bytesRead = is.read(buffer)) != -1) {
+                baos.write(buffer, 0, bytesRead);
+            }
+            return baos.toString("UTF-8");
+        } catch (IOException e) {
+            Log.e(TAG, "Failed to read ANR trace stream", e);
+            return null;
+        }
+    }
+}

--- a/app/src/main/java/com/bugsplat/android/BugSplat.java
+++ b/app/src/main/java/com/bugsplat/android/BugSplat.java
@@ -72,6 +72,16 @@ public class BugSplat {
     }
 
     /**
+     * Hang the calling thread indefinitely in a native infinite loop.
+     * Intended for testing ANR detection — call this from the main thread
+     * to trigger a system ANR with several symbolicated native frames in
+     * the resulting thread dump.
+     */
+    public static void hang() {
+        BugSplatBridge.hang();
+    }
+
+    /**
      * Set a custom attribute that will be included in crash reports.
      * This can be called at any time after init, and the value will be
      * captured in the next crash report.

--- a/app/src/main/java/com/bugsplat/android/BugSplat.java
+++ b/app/src/main/java/com/bugsplat/android/BugSplat.java
@@ -213,9 +213,31 @@ public class BugSplat {
     public static void postFeedback(String database, String application, String version,
                                     String title, String description, String user, String email,
                                     String appKey, List<File> attachments) {
+        postFeedback(database, application, version, title, description, user, email, appKey, attachments, null);
+    }
+
+    /**
+     * Post user feedback to BugSplat with file attachments and custom attributes.
+     * This runs on a background thread and returns immediately.
+     *
+     * @param database The BugSplat database name
+     * @param application The application name
+     * @param version The application version
+     * @param title The feedback title (becomes the stack key for grouping)
+     * @param description Additional feedback context
+     * @param user The user's name or id
+     * @param email The user's email
+     * @param appKey The application key for authentication
+     * @param attachments List of files to attach to the feedback report, or null for none
+     * @param attributes Custom key/value attributes to associate with the feedback, or null for none
+     */
+    public static void postFeedback(String database, String application, String version,
+                                    String title, String description, String user, String email,
+                                    String appKey, List<File> attachments,
+                                    Map<String, String> attributes) {
         new Thread(() -> {
             FeedbackClient client = new FeedbackClient(database, application, version);
-            client.postFeedback(title, description, user, email, appKey, attachments);
+            client.postFeedback(title, description, user, email, appKey, attachments, attributes);
         }).start();
     }
 
@@ -257,7 +279,30 @@ public class BugSplat {
     public static boolean postFeedbackBlocking(String database, String application, String version,
                                                String title, String description, String user, String email,
                                                String appKey, List<File> attachments) {
+        return postFeedbackBlocking(database, application, version, title, description, user, email, appKey, attachments, null);
+    }
+
+    /**
+     * Post user feedback to BugSplat with file attachments and custom attributes.
+     * This blocks until the upload is complete.
+     *
+     * @param database The BugSplat database name
+     * @param application The application name
+     * @param version The application version
+     * @param title The feedback title (becomes the stack key for grouping)
+     * @param description Additional feedback context
+     * @param user The user's name or id
+     * @param email The user's email
+     * @param appKey The application key for authentication
+     * @param attachments List of files to attach to the feedback report, or null for none
+     * @param attributes Custom key/value attributes to associate with the feedback, or null for none
+     * @return true if feedback was posted successfully
+     */
+    public static boolean postFeedbackBlocking(String database, String application, String version,
+                                               String title, String description, String user, String email,
+                                               String appKey, List<File> attachments,
+                                               Map<String, String> attributes) {
         FeedbackClient client = new FeedbackClient(database, application, version);
-        return client.postFeedback(title, description, user, email, appKey, attachments);
+        return client.postFeedback(title, description, user, email, appKey, attachments, attributes);
     }
 } 

--- a/app/src/main/java/com/bugsplat/android/BugSplatBridge.java
+++ b/app/src/main/java/com/bugsplat/android/BugSplatBridge.java
@@ -35,6 +35,10 @@ public class BugSplatBridge {
         Log.d("BugSplat", "init result: " +
                 jniInitBugSplat(applicationInfo.dataDir, applicationInfo.nativeLibraryDir, database, application,
                         version, attributes, attachments));
+
+        // Check for ANR reports from previous sessions (Android 11+)
+        AnrReporter anrReporter = new AnrReporter(activity, database, application, version);
+        anrReporter.checkAndReport();
     }
 
     public static void crash() {

--- a/app/src/main/java/com/bugsplat/android/BugSplatBridge.java
+++ b/app/src/main/java/com/bugsplat/android/BugSplatBridge.java
@@ -45,6 +45,14 @@ public class BugSplatBridge {
         jniCrash();
     }
 
+    /**
+     * Hang the calling thread in a native infinite loop. Intended for testing
+     * ANR detection and symbolication of native frames.
+     */
+    public static void hang() {
+        jniHang();
+    }
+
     public static void setAttribute(String key, String value) {
         validateAttributeKey(key);
         if (value == null) {
@@ -69,6 +77,8 @@ public class BugSplatBridge {
             String version, Map<String, String> attributes, String[] attachments);
 
     static native void jniCrash();
+
+    static native void jniHang();
 
     static native void jniSetAttribute(String key, String value);
 

--- a/app/src/main/java/com/bugsplat/android/CommitOptions.java
+++ b/app/src/main/java/com/bugsplat/android/CommitOptions.java
@@ -1,0 +1,59 @@
+package com.bugsplat.android;
+
+import org.json.JSONObject;
+
+import java.util.Map;
+
+/**
+ * Typed, optional fields for the {@code commitS3CrashUpload} request.
+ *
+ * Mirrors the documented BugSplat commit API 1-to-1:
+ * https://docs.bugsplat.com/introduction/development/web-services/crash#request-body-multipart-form-data
+ *
+ * All fields are optional. Use the fluent setters to populate only the fields
+ * you need. {@code appName}, {@code appVersion}, {@code s3Key}, {@code md5},
+ * and {@code database} are set by {@link ReportUploader} from constructor
+ * state and the upload flow, so they are not present here.
+ */
+class CommitOptions {
+    String crashType;
+    Integer crashTypeId;
+    Integer fullDumpFlag;
+    String appKey;
+    String description;
+    String user;
+    String email;
+    String internalIP;
+    String notes;
+    String processor;
+    String crashTime;
+    Map<String, String> attributes;
+    String crashHash;
+
+    CommitOptions() {}
+
+    CommitOptions crashType(String v) { this.crashType = v; return this; }
+    CommitOptions crashTypeId(int v) { this.crashTypeId = v; return this; }
+    CommitOptions fullDumpFlag(int v) { this.fullDumpFlag = v; return this; }
+    CommitOptions appKey(String v) { this.appKey = v; return this; }
+    CommitOptions description(String v) { this.description = v; return this; }
+    CommitOptions user(String v) { this.user = v; return this; }
+    CommitOptions email(String v) { this.email = v; return this; }
+    CommitOptions internalIP(String v) { this.internalIP = v; return this; }
+    CommitOptions notes(String v) { this.notes = v; return this; }
+    CommitOptions processor(String v) { this.processor = v; return this; }
+    CommitOptions crashTime(String v) { this.crashTime = v; return this; }
+    CommitOptions attributes(Map<String, String> v) { this.attributes = v; return this; }
+    CommitOptions crashHash(String v) { this.crashHash = v; return this; }
+
+    /**
+     * Return the attributes as a JSON string (the format the commit endpoint
+     * expects), or {@code null} if no attributes are set.
+     */
+    String attributesJson() {
+        if (attributes == null || attributes.isEmpty()) {
+            return null;
+        }
+        return new JSONObject(attributes).toString();
+    }
+}

--- a/app/src/main/java/com/bugsplat/android/FeedbackClient.java
+++ b/app/src/main/java/com/bugsplat/android/FeedbackClient.java
@@ -2,6 +2,9 @@ package com.bugsplat.android;
 
 import android.util.Log;
 
+import org.json.JSONException;
+import org.json.JSONObject;
+
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -10,14 +13,22 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * Posts User Feedback reports to BugSplat via the 3-part presigned-URL flow.
+ *
+ * The feedback body is a JSON document ({@code feedback.json}) containing
+ * {@code title} and (optionally) {@code description}. Metadata like
+ * {@code user}, {@code email}, and {@code appKey} is attached on the
+ * {@code commitS3CrashUpload} request — not baked into the JSON body.
+ *
+ * See <a href="https://docs.bugsplat.com/introduction/development/web-services/user-feedback">
+ * BugSplat User Feedback docs</a>.
+ */
 class FeedbackClient {
     private static final String TAG = "BugSplat";
-    private static final String CRASH_TYPE = "UserFeedback";
+    private static final String CRASH_TYPE = "User.Feedback";
     private static final int CRASH_TYPE_ID = 36;
 
-    private final String database;
-    private final String application;
-    private final String version;
     private final ReportUploader uploader;
 
     FeedbackClient(String database, String application, String version) {
@@ -26,38 +37,32 @@ class FeedbackClient {
 
     /** Package-private constructor for testing with a custom uploader. */
     FeedbackClient(String database, String application, String version, ReportUploader uploader) {
-        this.database = database;
-        this.application = application;
-        this.version = version;
         this.uploader = uploader;
     }
 
     boolean postFeedback(String title, String description, String user, String email, String appKey) {
-        return postFeedback(title, description, user, email, appKey, null);
+        return postFeedback(title, description, user, email, appKey, null, null);
     }
 
-    boolean postFeedback(String title, String description, String user, String email, String appKey, List<File> attachments) {
+    boolean postFeedback(String title, String description, String user, String email, String appKey,
+                         List<File> attachments) {
+        return postFeedback(title, description, user, email, appKey, attachments, null);
+    }
+
+    boolean postFeedback(String title, String description, String user, String email, String appKey,
+                         List<File> attachments, Map<String, String> attributes) {
         try {
-            // Build a simple text report with the feedback fields.
-            StringBuilder report = new StringBuilder();
-            report.append("Title: ").append(title != null ? title : "").append("\n");
+            // Build the feedback.json body — only title (required) and description (optional).
+            // The other fields (user, email, description, appKey, attributes) go on the commit request.
+            JSONObject json = new JSONObject();
+            json.put("title", title != null ? title : "");
             if (description != null && !description.isEmpty()) {
-                report.append("Description: ").append(description).append("\n");
-            }
-            if (user != null && !user.isEmpty()) {
-                report.append("User: ").append(user).append("\n");
-            }
-            if (email != null && !email.isEmpty()) {
-                report.append("Email: ").append(email).append("\n");
-            }
-            if (appKey != null && !appKey.isEmpty()) {
-                report.append("AppKey: ").append(appKey).append("\n");
+                json.put("description", description);
             }
 
-            // Pack the report plus any attachment bytes into a single zip
-            // (LinkedHashMap preserves insertion order so feedback.txt is first).
+            // LinkedHashMap preserves iteration order so feedback.json is first in the zip.
             Map<String, byte[]> entries = new LinkedHashMap<>();
-            entries.put("feedback.txt", report.toString().getBytes(StandardCharsets.UTF_8));
+            entries.put("feedback.json", json.toString().getBytes(StandardCharsets.UTF_8));
 
             if (attachments != null) {
                 for (File file : attachments) {
@@ -69,7 +74,18 @@ class FeedbackClient {
                 }
             }
 
-            boolean success = uploader.upload(entries, CRASH_TYPE, CRASH_TYPE_ID);
+            // Extra commit fields per the User Feedback / Crash API docs.
+            Map<String, String> commitFields = new LinkedHashMap<>();
+            if (user != null && !user.isEmpty()) commitFields.put("user", user);
+            if (email != null && !email.isEmpty()) commitFields.put("email", email);
+            if (description != null && !description.isEmpty()) commitFields.put("description", description);
+            if (appKey != null && !appKey.isEmpty()) commitFields.put("appKey", appKey);
+            if (attributes != null && !attributes.isEmpty()) {
+                // Per the API docs, `attributes` is a JSON string of custom attributes.
+                commitFields.put("attributes", new JSONObject(attributes).toString());
+            }
+
+            boolean success = uploader.upload(entries, CRASH_TYPE, CRASH_TYPE_ID, commitFields);
             if (success) {
                 Log.i(TAG, "Feedback posted successfully");
             } else {
@@ -77,7 +93,7 @@ class FeedbackClient {
             }
             return success;
 
-        } catch (Exception e) {
+        } catch (JSONException | IOException e) {
             Log.e(TAG, "Failed to post feedback", e);
             return false;
         }

--- a/app/src/main/java/com/bugsplat/android/FeedbackClient.java
+++ b/app/src/main/java/com/bugsplat/android/FeedbackClient.java
@@ -3,27 +3,31 @@ package com.bugsplat.android;
 import android.util.Log;
 
 import java.io.ByteArrayOutputStream;
-import java.io.DataOutputStream;
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.OutputStream;
-import java.net.HttpURLConnection;
-import java.net.URL;
+import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
-import java.util.UUID;
 
 class FeedbackClient {
     private static final String TAG = "BugSplat";
+    private static final String CRASH_TYPE = "UserFeedback";
+    private static final int CRASH_TYPE_ID = 36;
 
     private final String database;
     private final String application;
     private final String version;
+    private final ReportUploader uploader;
 
     FeedbackClient(String database, String application, String version) {
+        this(database, application, version, new ReportUploader(database, application, version));
+    }
+
+    /** Package-private constructor for testing with a custom uploader. */
+    FeedbackClient(String database, String application, String version, ReportUploader uploader) {
         this.database = database;
         this.application = application;
         this.version = version;
+        this.uploader = uploader;
     }
 
     boolean postFeedback(String title, String description, String user, String email, String appKey) {
@@ -32,100 +36,49 @@ class FeedbackClient {
 
     boolean postFeedback(String title, String description, String user, String email, String appKey, List<File> attachments) {
         try {
-            String url = "https://" + database + ".bugsplat.com/post/feedback/";
-            String boundary = UUID.randomUUID().toString();
+            // Build a simple text report with the feedback fields
+            StringBuilder report = new StringBuilder();
+            report.append("Title: ").append(title != null ? title : "").append("\n");
+            if (description != null && !description.isEmpty()) {
+                report.append("Description: ").append(description).append("\n");
+            }
+            if (user != null && !user.isEmpty()) {
+                report.append("User: ").append(user).append("\n");
+            }
+            if (email != null && !email.isEmpty()) {
+                report.append("Email: ").append(email).append("\n");
+            }
+            if (appKey != null && !appKey.isEmpty()) {
+                report.append("AppKey: ").append(appKey).append("\n");
+            }
 
-            HttpURLConnection conn = (HttpURLConnection) new URL(url).openConnection();
-            try {
-                conn.setRequestMethod("POST");
-                conn.setDoOutput(true);
-                conn.setConnectTimeout(30000);
-                conn.setReadTimeout(30000);
-                conn.setRequestProperty("Content-Type", "multipart/form-data; boundary=" + boundary);
-
-                ByteArrayOutputStream baos = new ByteArrayOutputStream();
-                DataOutputStream dos = new DataOutputStream(baos);
-
-                // Required fields
-                writeFormField(dos, boundary, "database", database);
-                writeFormField(dos, boundary, "appName", application);
-                writeFormField(dos, boundary, "appVersion", version);
-                writeFormField(dos, boundary, "title", title);
-
-                // Optional fields
-                if (description != null && !description.isEmpty()) {
-                    writeFormField(dos, boundary, "description", description);
-                }
-                if (user != null && !user.isEmpty()) {
-                    writeFormField(dos, boundary, "user", user);
-                }
-                if (email != null && !email.isEmpty()) {
-                    writeFormField(dos, boundary, "email", email);
-                }
-                if (appKey != null && !appKey.isEmpty()) {
-                    writeFormField(dos, boundary, "appKey", appKey);
-                }
-
-                // File attachments
-                if (attachments != null) {
-                    for (File file : attachments) {
-                        if (file == null || !file.exists() || !file.isFile()) {
-                            Log.w(TAG, "Skipping invalid attachment: " + file);
-                            continue;
-                        }
-                        writeFileField(dos, boundary, file.getName(), file);
-                        Log.d(TAG, "Attached file " + file.getName() + " (" + file.length() + " bytes)");
+            // Add attachment info
+            if (attachments != null) {
+                for (File file : attachments) {
+                    if (file != null && file.exists() && file.isFile()) {
+                        report.append("Attachment: ").append(file.getName())
+                              .append(" (").append(file.length()).append(" bytes)\n");
                     }
                 }
-
-                dos.write(("--" + boundary + "--\r\n").getBytes(StandardCharsets.UTF_8));
-                dos.flush();
-
-                byte[] payload = baos.toByteArray();
-                conn.setRequestProperty("Content-Length", String.valueOf(payload.length));
-                try (OutputStream out = conn.getOutputStream()) {
-                    out.write(payload);
-                    out.flush();
-                }
-
-                int status = conn.getResponseCode();
-
-                if (status >= 200 && status < 300) {
-                    Log.i(TAG, "Feedback posted successfully (HTTP " + status + ")");
-                    return true;
-                } else {
-                    Log.e(TAG, "Failed to post feedback (HTTP " + status + ")");
-                    return false;
-                }
-            } finally {
-                conn.disconnect();
             }
+
+            boolean success = uploader.upload(
+                    report.toString().getBytes(StandardCharsets.UTF_8),
+                    "feedback.txt",
+                    CRASH_TYPE,
+                    CRASH_TYPE_ID
+            );
+
+            if (success) {
+                Log.i(TAG, "Feedback posted successfully");
+            } else {
+                Log.e(TAG, "Failed to post feedback");
+            }
+            return success;
 
         } catch (Exception e) {
             Log.e(TAG, "Failed to post feedback", e);
             return false;
         }
-    }
-
-    private void writeFormField(DataOutputStream dos, String boundary, String name, String value) throws Exception {
-        dos.write(("--" + boundary + "\r\n").getBytes(StandardCharsets.UTF_8));
-        dos.write(("Content-Disposition: form-data; name=\"" + name + "\"\r\n\r\n").getBytes(StandardCharsets.UTF_8));
-        dos.write(value.getBytes(StandardCharsets.UTF_8));
-        dos.write("\r\n".getBytes(StandardCharsets.UTF_8));
-    }
-
-    private void writeFileField(DataOutputStream dos, String boundary, String fieldName, File file) throws Exception {
-        dos.write(("--" + boundary + "\r\n").getBytes(StandardCharsets.UTF_8));
-        dos.write(("Content-Disposition: form-data; name=\"" + fieldName + "\"; filename=\"" + file.getName() + "\"\r\n").getBytes(StandardCharsets.UTF_8));
-        dos.write("Content-Type: application/octet-stream\r\n\r\n".getBytes(StandardCharsets.UTF_8));
-
-        byte[] buffer = new byte[4096];
-        try (FileInputStream fis = new FileInputStream(file)) {
-            int bytesRead;
-            while ((bytesRead = fis.read(buffer)) != -1) {
-                dos.write(buffer, 0, bytesRead);
-            }
-        }
-        dos.write("\r\n".getBytes(StandardCharsets.UTF_8));
     }
 }

--- a/app/src/main/java/com/bugsplat/android/FeedbackClient.java
+++ b/app/src/main/java/com/bugsplat/android/FeedbackClient.java
@@ -5,20 +5,22 @@ import android.util.Log;
 import org.json.JSONException;
 import org.json.JSONObject;
 
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
 
 /**
  * Posts User Feedback reports to BugSplat via the 3-part presigned-URL flow.
  *
  * The feedback body is a JSON document ({@code feedback.json}) containing
  * {@code title} and (optionally) {@code description}. Metadata like
- * {@code user}, {@code email}, and {@code appKey} is attached on the
+ * {@code user}, {@code email}, and {@code appKey} are attached on the
  * {@code commitS3CrashUpload} request — not baked into the JSON body.
  *
  * See <a href="https://docs.bugsplat.com/introduction/development/web-services/user-feedback">
@@ -52,40 +54,28 @@ class FeedbackClient {
     boolean postFeedback(String title, String description, String user, String email, String appKey,
                          List<File> attachments, Map<String, String> attributes) {
         try {
-            // Build the feedback.json body — only title (required) and description (optional).
-            // The other fields (user, email, description, appKey, attributes) go on the commit request.
+            // feedback.json — per the User Feedback API, only title (required)
+            // and description (optional) live in the JSON; the rest are
+            // commit-request fields below.
             JSONObject json = new JSONObject();
             json.put("title", title != null ? title : "");
             if (description != null && !description.isEmpty()) {
                 json.put("description", description);
             }
+            byte[] jsonBytes = json.toString().getBytes(StandardCharsets.UTF_8);
 
-            // LinkedHashMap preserves iteration order so feedback.json is first in the zip.
-            Map<String, byte[]> entries = new LinkedHashMap<>();
-            entries.put("feedback.json", json.toString().getBytes(StandardCharsets.UTF_8));
+            byte[] zipped = buildZip(jsonBytes, attachments);
 
-            if (attachments != null) {
-                for (File file : attachments) {
-                    if (file == null || !file.exists() || !file.isFile()) {
-                        Log.w(TAG, "Skipping invalid attachment: " + file);
-                        continue;
-                    }
-                    entries.put(uniqueEntryName(entries, file.getName()), readFileBytes(file));
-                }
-            }
+            CommitOptions options = new CommitOptions()
+                    .crashType(CRASH_TYPE)
+                    .crashTypeId(CRASH_TYPE_ID)
+                    .user(user)
+                    .email(email)
+                    .description(description)
+                    .appKey(appKey)
+                    .attributes(attributes);
 
-            // Extra commit fields per the User Feedback / Crash API docs.
-            Map<String, String> commitFields = new LinkedHashMap<>();
-            if (user != null && !user.isEmpty()) commitFields.put("user", user);
-            if (email != null && !email.isEmpty()) commitFields.put("email", email);
-            if (description != null && !description.isEmpty()) commitFields.put("description", description);
-            if (appKey != null && !appKey.isEmpty()) commitFields.put("appKey", appKey);
-            if (attributes != null && !attributes.isEmpty()) {
-                // Per the API docs, `attributes` is a JSON string of custom attributes.
-                commitFields.put("attributes", new JSONObject(attributes).toString());
-            }
-
-            boolean success = uploader.upload(entries, CRASH_TYPE, CRASH_TYPE_ID, commitFields);
+            boolean success = uploader.upload(zipped, options);
             if (success) {
                 Log.i(TAG, "Feedback posted successfully");
             } else {
@@ -99,31 +89,38 @@ class FeedbackClient {
         }
     }
 
-    private static byte[] readFileBytes(File file) throws IOException {
-        byte[] data = new byte[(int) file.length()];
-        try (FileInputStream fis = new FileInputStream(file)) {
-            int offset = 0;
-            while (offset < data.length) {
-                int read = fis.read(data, offset, data.length - offset);
-                if (read < 0) break;
-                offset += read;
+    /**
+     * Build the feedback zip: feedback.json first, then each attachment
+     * streamed directly from disk (not buffered fully in memory).
+     * Attachment filenames are used as-is for zip entry names — callers are
+     * responsible for ensuring they don't collide with each other or with
+     * {@code feedback.json}.
+     */
+    private static byte[] buildZip(byte[] feedbackJson, List<File> attachments) throws IOException {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (ZipOutputStream zos = new ZipOutputStream(baos)) {
+            zos.putNextEntry(new ZipEntry("feedback.json"));
+            zos.write(feedbackJson);
+            zos.closeEntry();
+
+            if (attachments != null) {
+                byte[] buffer = new byte[8192];
+                for (File file : attachments) {
+                    if (file == null || !file.exists() || !file.isFile()) {
+                        Log.w(TAG, "Skipping invalid attachment: " + file);
+                        continue;
+                    }
+                    zos.putNextEntry(new ZipEntry(file.getName()));
+                    try (FileInputStream fis = new FileInputStream(file)) {
+                        int n;
+                        while ((n = fis.read(buffer)) != -1) {
+                            zos.write(buffer, 0, n);
+                        }
+                    }
+                    zos.closeEntry();
+                }
             }
         }
-        return data;
-    }
-
-    /** Disambiguate entries if two attachments share a filename. */
-    private static String uniqueEntryName(Map<String, byte[]> entries, String name) {
-        if (!entries.containsKey(name)) return name;
-        int dot = name.lastIndexOf('.');
-        String base = dot > 0 ? name.substring(0, dot) : name;
-        String ext = dot > 0 ? name.substring(dot) : "";
-        int n = 1;
-        String candidate;
-        do {
-            candidate = base + "_" + n + ext;
-            n++;
-        } while (entries.containsKey(candidate));
-        return candidate;
+        return baos.toByteArray();
     }
 }

--- a/app/src/main/java/com/bugsplat/android/FeedbackClient.java
+++ b/app/src/main/java/com/bugsplat/android/FeedbackClient.java
@@ -2,11 +2,13 @@ package com.bugsplat.android;
 
 import android.util.Log;
 
-import java.io.ByteArrayOutputStream;
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 class FeedbackClient {
     private static final String TAG = "BugSplat";
@@ -36,7 +38,7 @@ class FeedbackClient {
 
     boolean postFeedback(String title, String description, String user, String email, String appKey, List<File> attachments) {
         try {
-            // Build a simple text report with the feedback fields
+            // Build a simple text report with the feedback fields.
             StringBuilder report = new StringBuilder();
             report.append("Title: ").append(title != null ? title : "").append("\n");
             if (description != null && !description.isEmpty()) {
@@ -52,23 +54,22 @@ class FeedbackClient {
                 report.append("AppKey: ").append(appKey).append("\n");
             }
 
-            // Add attachment info
+            // Pack the report plus any attachment bytes into a single zip
+            // (LinkedHashMap preserves insertion order so feedback.txt is first).
+            Map<String, byte[]> entries = new LinkedHashMap<>();
+            entries.put("feedback.txt", report.toString().getBytes(StandardCharsets.UTF_8));
+
             if (attachments != null) {
                 for (File file : attachments) {
-                    if (file != null && file.exists() && file.isFile()) {
-                        report.append("Attachment: ").append(file.getName())
-                              .append(" (").append(file.length()).append(" bytes)\n");
+                    if (file == null || !file.exists() || !file.isFile()) {
+                        Log.w(TAG, "Skipping invalid attachment: " + file);
+                        continue;
                     }
+                    entries.put(uniqueEntryName(entries, file.getName()), readFileBytes(file));
                 }
             }
 
-            boolean success = uploader.upload(
-                    report.toString().getBytes(StandardCharsets.UTF_8),
-                    "feedback.txt",
-                    CRASH_TYPE,
-                    CRASH_TYPE_ID
-            );
-
+            boolean success = uploader.upload(entries, CRASH_TYPE, CRASH_TYPE_ID);
             if (success) {
                 Log.i(TAG, "Feedback posted successfully");
             } else {
@@ -80,5 +81,33 @@ class FeedbackClient {
             Log.e(TAG, "Failed to post feedback", e);
             return false;
         }
+    }
+
+    private static byte[] readFileBytes(File file) throws IOException {
+        byte[] data = new byte[(int) file.length()];
+        try (FileInputStream fis = new FileInputStream(file)) {
+            int offset = 0;
+            while (offset < data.length) {
+                int read = fis.read(data, offset, data.length - offset);
+                if (read < 0) break;
+                offset += read;
+            }
+        }
+        return data;
+    }
+
+    /** Disambiguate entries if two attachments share a filename. */
+    private static String uniqueEntryName(Map<String, byte[]> entries, String name) {
+        if (!entries.containsKey(name)) return name;
+        int dot = name.lastIndexOf('.');
+        String base = dot > 0 ? name.substring(0, dot) : name;
+        String ext = dot > 0 ? name.substring(dot) : "";
+        int n = 1;
+        String candidate;
+        do {
+            candidate = base + "_" + n + ext;
+            n++;
+        } while (entries.containsKey(candidate));
+        return candidate;
     }
 }

--- a/app/src/main/java/com/bugsplat/android/ReportUploader.java
+++ b/app/src/main/java/com/bugsplat/android/ReportUploader.java
@@ -15,7 +15,9 @@ import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
+import java.util.Map;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
@@ -51,13 +53,15 @@ class ReportUploader {
      * Upload a file using the 3-part S3 upload flow.
      *
      * @param file       The file to upload
-     * @param crashType  The crash type string (e.g. "Android ANR", "Feedback")
+     * @param crashType  The crash type string (e.g. "Android ANR", "UserFeedback")
      * @param crashTypeId The crash type ID
      * @return true if the upload succeeded
      */
     boolean upload(File file, String crashType, int crashTypeId) throws IOException {
-        byte[] zipped = createZip(file.getName(), new FileInputStream(file));
-        return uploadZipped(zipped, file.getName(), crashType, crashTypeId);
+        try (FileInputStream fis = new FileInputStream(file)) {
+            byte[] zipped = createZip(file.getName(), fis);
+            return uploadZipped(zipped, file.getName(), crashType, crashTypeId);
+        }
     }
 
     /**
@@ -65,13 +69,33 @@ class ReportUploader {
      *
      * @param data       The data to upload
      * @param fileName   The filename for the zip entry
-     * @param crashType  The crash type string (e.g. "Android ANR", "Feedback")
+     * @param crashType  The crash type string (e.g. "Android ANR", "UserFeedback")
      * @param crashTypeId The crash type ID
      * @return true if the upload succeeded
      */
     boolean upload(byte[] data, String fileName, String crashType, int crashTypeId) throws IOException {
         byte[] zipped = createZip(fileName, new ByteArrayInputStream(data));
         return uploadZipped(zipped, fileName, crashType, crashTypeId);
+    }
+
+    /**
+     * Upload multiple entries packed into a single zip using the 3-part S3 upload flow.
+     * Entries are added to the zip in the iteration order of {@code entries}.
+     * Used by feedback uploads which bundle the report + attached files into one zip.
+     *
+     * @param entries    Map of zip-entry name to bytes. Must not be empty.
+     * @param crashType  The crash type string
+     * @param crashTypeId The crash type ID
+     * @return true if the upload succeeded
+     */
+    boolean upload(Map<String, byte[]> entries, String crashType, int crashTypeId) throws IOException {
+        if (entries == null || entries.isEmpty()) {
+            throw new IllegalArgumentException("entries must not be empty");
+        }
+        byte[] zipped = createZip(entries);
+        // Use the first entry's name as the zip label for logging
+        String zipName = entries.keySet().iterator().next();
+        return uploadZipped(zipped, zipName, crashType, crashTypeId);
     }
 
     private boolean uploadZipped(byte[] zipped, String fileName, String crashType, int crashTypeId) throws IOException {
@@ -104,9 +128,9 @@ class ReportUploader {
 
     private String getCrashUploadUrl(int size) throws IOException {
         String urlStr = getBaseUrl() + "/api/getCrashUploadUrl"
-                + "?database=" + database
-                + "&appName=" + application
-                + "&appVersion=" + version
+                + "?database=" + urlEncode(database)
+                + "&appName=" + urlEncode(application)
+                + "&appVersion=" + urlEncode(version)
                 + "&crashPostSize=" + size;
 
         HttpURLConnection conn = (HttpURLConnection) new URL(urlStr).openConnection();
@@ -120,7 +144,7 @@ class ReportUploader {
                 Log.w(TAG, "Rate limited by server");
                 return null;
             }
-            if (status != 200) {
+            if (status < 200 || status >= 300) {
                 Log.e(TAG, "getCrashUploadUrl failed (HTTP " + status + ")");
                 return null;
             }
@@ -153,7 +177,7 @@ class ReportUploader {
             }
 
             int status = conn.getResponseCode();
-            if (status != 200) {
+            if (status < 200 || status >= 300) {
                 Log.e(TAG, "S3 PUT failed (HTTP " + status + ")");
                 return false;
             }
@@ -183,7 +207,7 @@ class ReportUploader {
             writeField(baos, boundary, "crashTypeId", String.valueOf(crashTypeId));
             writeField(baos, boundary, "s3key", s3Key);
             writeField(baos, boundary, "md5", md5);
-            baos.write(("--" + boundary + "--\r\n").getBytes("UTF-8"));
+            baos.write(("--" + boundary + "--\r\n").getBytes(StandardCharsets.UTF_8));
 
             byte[] payload = baos.toByteArray();
             conn.setRequestProperty("Content-Length", String.valueOf(payload.length));
@@ -209,6 +233,10 @@ class ReportUploader {
 
     // -- Utilities --
 
+    /**
+     * Create a zip containing a single entry. Does not close {@code data};
+     * callers are responsible for closing it.
+     */
     static byte[] createZip(String entryName, InputStream data) throws IOException {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         try (ZipOutputStream zos = new ZipOutputStream(baos)) {
@@ -219,6 +247,19 @@ class ReportUploader {
                 zos.write(buffer, 0, bytesRead);
             }
             zos.closeEntry();
+        }
+        return baos.toByteArray();
+    }
+
+    /** Create a zip containing multiple entries (name → bytes). */
+    static byte[] createZip(Map<String, byte[]> entries) throws IOException {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (ZipOutputStream zos = new ZipOutputStream(baos)) {
+            for (Map.Entry<String, byte[]> entry : entries.entrySet()) {
+                zos.putNextEntry(new ZipEntry(entry.getKey()));
+                zos.write(entry.getValue());
+                zos.closeEntry();
+            }
         }
         return baos.toByteArray();
     }
@@ -239,7 +280,7 @@ class ReportUploader {
 
     static String readBody(InputStream stream) throws IOException {
         if (stream == null) return "";
-        try (BufferedReader reader = new BufferedReader(new InputStreamReader(stream))) {
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(stream, StandardCharsets.UTF_8))) {
             StringBuilder sb = new StringBuilder();
             String line;
             while ((line = reader.readLine()) != null) {
@@ -251,9 +292,18 @@ class ReportUploader {
 
     private static void writeField(ByteArrayOutputStream baos, String boundary,
                                    String name, String value) throws IOException {
-        baos.write(("--" + boundary + "\r\n").getBytes("UTF-8"));
-        baos.write(("Content-Disposition: form-data; name=\"" + name + "\"\r\n\r\n").getBytes("UTF-8"));
-        baos.write(value.getBytes("UTF-8"));
-        baos.write("\r\n".getBytes("UTF-8"));
+        baos.write(("--" + boundary + "\r\n").getBytes(StandardCharsets.UTF_8));
+        baos.write(("Content-Disposition: form-data; name=\"" + name + "\"\r\n\r\n").getBytes(StandardCharsets.UTF_8));
+        baos.write(value.getBytes(StandardCharsets.UTF_8));
+        baos.write("\r\n".getBytes(StandardCharsets.UTF_8));
+    }
+
+    private static String urlEncode(String value) {
+        try {
+            return java.net.URLEncoder.encode(value, "UTF-8");
+        } catch (java.io.UnsupportedEncodingException e) {
+            // UTF-8 is always supported.
+            throw new AssertionError(e);
+        }
     }
 }

--- a/app/src/main/java/com/bugsplat/android/ReportUploader.java
+++ b/app/src/main/java/com/bugsplat/android/ReportUploader.java
@@ -1,0 +1,259 @@
+package com.bugsplat.android;
+
+import android.util.Log;
+
+import org.json.JSONObject;
+
+import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.security.MessageDigest;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+/**
+ * Implements the BugSplat 3-part upload flow:
+ * <ol>
+ *   <li>GET /api/getCrashUploadUrl — obtain a presigned S3 URL</li>
+ *   <li>PUT the zipped payload to the presigned URL</li>
+ *   <li>POST /api/commitS3CrashUpload — commit with metadata</li>
+ * </ol>
+ */
+class ReportUploader {
+    private static final String TAG = "BugSplat-Upload";
+    private static final int CONNECT_TIMEOUT_MS = 15_000;
+    private static final int READ_TIMEOUT_MS = 30_000;
+
+    private final String database;
+    private final String application;
+    private final String version;
+
+    ReportUploader(String database, String application, String version) {
+        this.database = database;
+        this.application = application;
+        this.version = version;
+    }
+
+    /** Returns the base URL for API calls. Overridable for testing. */
+    String getBaseUrl() {
+        return "https://" + database + ".bugsplat.com";
+    }
+
+    /**
+     * Upload a file using the 3-part S3 upload flow.
+     *
+     * @param file       The file to upload
+     * @param crashType  The crash type string (e.g. "Android ANR", "Feedback")
+     * @param crashTypeId The crash type ID
+     * @return true if the upload succeeded
+     */
+    boolean upload(File file, String crashType, int crashTypeId) throws IOException {
+        byte[] zipped = createZip(file.getName(), new FileInputStream(file));
+        return uploadZipped(zipped, file.getName(), crashType, crashTypeId);
+    }
+
+    /**
+     * Upload raw bytes using the 3-part S3 upload flow.
+     *
+     * @param data       The data to upload
+     * @param fileName   The filename for the zip entry
+     * @param crashType  The crash type string (e.g. "Android ANR", "Feedback")
+     * @param crashTypeId The crash type ID
+     * @return true if the upload succeeded
+     */
+    boolean upload(byte[] data, String fileName, String crashType, int crashTypeId) throws IOException {
+        byte[] zipped = createZip(fileName, new ByteArrayInputStream(data));
+        return uploadZipped(zipped, fileName, crashType, crashTypeId);
+    }
+
+    private boolean uploadZipped(byte[] zipped, String fileName, String crashType, int crashTypeId) throws IOException {
+        String md5 = md5Hex(zipped);
+
+        // Step 1: Get presigned upload URL
+        String presignedUrl = getCrashUploadUrl(zipped.length);
+        if (presignedUrl == null) {
+            Log.e(TAG, "Failed to get crash upload URL");
+            return false;
+        }
+        Log.d(TAG, "Got presigned URL for " + fileName);
+
+        // Step 2: PUT the zip to S3
+        if (!uploadToPresignedUrl(presignedUrl, zipped)) {
+            Log.e(TAG, "Failed to upload to presigned URL");
+            return false;
+        }
+        Log.d(TAG, "Uploaded " + fileName + " to S3 (" + zipped.length + " bytes)");
+
+        // Step 3: Commit
+        if (!commitUpload(presignedUrl, crashType, crashTypeId, md5)) {
+            Log.e(TAG, "Failed to commit upload");
+            return false;
+        }
+        Log.i(TAG, "Upload committed: " + fileName + " (" + crashType + ")");
+
+        return true;
+    }
+
+    private String getCrashUploadUrl(int size) throws IOException {
+        String urlStr = getBaseUrl() + "/api/getCrashUploadUrl"
+                + "?database=" + database
+                + "&appName=" + application
+                + "&appVersion=" + version
+                + "&crashPostSize=" + size;
+
+        HttpURLConnection conn = (HttpURLConnection) new URL(urlStr).openConnection();
+        try {
+            conn.setRequestMethod("GET");
+            conn.setConnectTimeout(CONNECT_TIMEOUT_MS);
+            conn.setReadTimeout(READ_TIMEOUT_MS);
+
+            int status = conn.getResponseCode();
+            if (status == 429) {
+                Log.w(TAG, "Rate limited by server");
+                return null;
+            }
+            if (status != 200) {
+                Log.e(TAG, "getCrashUploadUrl failed (HTTP " + status + ")");
+                return null;
+            }
+
+            String body = readBody(conn.getInputStream());
+            JSONObject json = new JSONObject(body);
+            return json.getString("url");
+        } catch (Exception e) {
+            Log.e(TAG, "getCrashUploadUrl error", e);
+            return null;
+        } finally {
+            conn.disconnect();
+        }
+    }
+
+    private boolean uploadToPresignedUrl(String presignedUrl, byte[] data) throws IOException {
+        HttpURLConnection conn = (HttpURLConnection) new URL(presignedUrl).openConnection();
+        try {
+            conn.setRequestMethod("PUT");
+            conn.setDoOutput(true);
+            conn.setConnectTimeout(CONNECT_TIMEOUT_MS);
+            conn.setReadTimeout(READ_TIMEOUT_MS);
+            conn.setRequestProperty("Content-Type", "application/octet-stream");
+            conn.setRequestProperty("Content-Length", String.valueOf(data.length));
+            conn.setFixedLengthStreamingMode(data.length);
+
+            try (OutputStream out = conn.getOutputStream()) {
+                out.write(data);
+                out.flush();
+            }
+
+            int status = conn.getResponseCode();
+            if (status != 200) {
+                Log.e(TAG, "S3 PUT failed (HTTP " + status + ")");
+                return false;
+            }
+            return true;
+        } finally {
+            conn.disconnect();
+        }
+    }
+
+    private boolean commitUpload(String s3Key, String crashType, int crashTypeId, String md5) throws IOException {
+        String urlStr = getBaseUrl() + "/api/commitS3CrashUpload";
+        String boundary = java.util.UUID.randomUUID().toString();
+
+        HttpURLConnection conn = (HttpURLConnection) new URL(urlStr).openConnection();
+        try {
+            conn.setRequestMethod("POST");
+            conn.setDoOutput(true);
+            conn.setConnectTimeout(CONNECT_TIMEOUT_MS);
+            conn.setReadTimeout(READ_TIMEOUT_MS);
+            conn.setRequestProperty("Content-Type", "multipart/form-data; boundary=" + boundary);
+
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            writeField(baos, boundary, "database", database);
+            writeField(baos, boundary, "appName", application);
+            writeField(baos, boundary, "appVersion", version);
+            writeField(baos, boundary, "crashType", crashType);
+            writeField(baos, boundary, "crashTypeId", String.valueOf(crashTypeId));
+            writeField(baos, boundary, "s3key", s3Key);
+            writeField(baos, boundary, "md5", md5);
+            baos.write(("--" + boundary + "--\r\n").getBytes("UTF-8"));
+
+            byte[] payload = baos.toByteArray();
+            conn.setRequestProperty("Content-Length", String.valueOf(payload.length));
+            conn.setFixedLengthStreamingMode(payload.length);
+
+            try (OutputStream out = conn.getOutputStream()) {
+                out.write(payload);
+                out.flush();
+            }
+
+            int status = conn.getResponseCode();
+            if (status >= 200 && status < 300) {
+                return true;
+            } else {
+                String body = readBody(status >= 400 ? conn.getErrorStream() : conn.getInputStream());
+                Log.e(TAG, "commitS3CrashUpload failed (HTTP " + status + "): " + body);
+                return false;
+            }
+        } finally {
+            conn.disconnect();
+        }
+    }
+
+    // -- Utilities --
+
+    static byte[] createZip(String entryName, InputStream data) throws IOException {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (ZipOutputStream zos = new ZipOutputStream(baos)) {
+            zos.putNextEntry(new ZipEntry(entryName));
+            byte[] buffer = new byte[4096];
+            int bytesRead;
+            while ((bytesRead = data.read(buffer)) != -1) {
+                zos.write(buffer, 0, bytesRead);
+            }
+            zos.closeEntry();
+        }
+        return baos.toByteArray();
+    }
+
+    static String md5Hex(byte[] data) {
+        try {
+            MessageDigest md = MessageDigest.getInstance("MD5");
+            byte[] digest = md.digest(data);
+            StringBuilder sb = new StringBuilder(32);
+            for (byte b : digest) {
+                sb.append(String.format("%02x", b & 0xff));
+            }
+            return sb.toString();
+        } catch (Exception e) {
+            throw new RuntimeException("MD5 not available", e);
+        }
+    }
+
+    static String readBody(InputStream stream) throws IOException {
+        if (stream == null) return "";
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(stream))) {
+            StringBuilder sb = new StringBuilder();
+            String line;
+            while ((line = reader.readLine()) != null) {
+                sb.append(line);
+            }
+            return sb.toString();
+        }
+    }
+
+    private static void writeField(ByteArrayOutputStream baos, String boundary,
+                                   String name, String value) throws IOException {
+        baos.write(("--" + boundary + "\r\n").getBytes("UTF-8"));
+        baos.write(("Content-Disposition: form-data; name=\"" + name + "\"\r\n\r\n").getBytes("UTF-8"));
+        baos.write(value.getBytes("UTF-8"));
+        baos.write("\r\n".getBytes("UTF-8"));
+    }
+}

--- a/app/src/main/java/com/bugsplat/android/ReportUploader.java
+++ b/app/src/main/java/com/bugsplat/android/ReportUploader.java
@@ -53,7 +53,7 @@ class ReportUploader {
      * Upload a file using the 3-part S3 upload flow.
      *
      * @param file       The file to upload
-     * @param crashType  The crash type string (e.g. "Android ANR", "UserFeedback")
+     * @param crashType  The crash type string (e.g. "Android.ANR", "User.Feedback")
      * @param crashTypeId The crash type ID
      * @return true if the upload succeeded
      */
@@ -69,7 +69,7 @@ class ReportUploader {
      *
      * @param data       The data to upload
      * @param fileName   The filename for the zip entry
-     * @param crashType  The crash type string (e.g. "Android ANR", "UserFeedback")
+     * @param crashType  The crash type string (e.g. "Android.ANR", "User.Feedback")
      * @param crashTypeId The crash type ID
      * @return true if the upload succeeded
      */
@@ -81,7 +81,6 @@ class ReportUploader {
     /**
      * Upload multiple entries packed into a single zip using the 3-part S3 upload flow.
      * Entries are added to the zip in the iteration order of {@code entries}.
-     * Used by feedback uploads which bundle the report + attached files into one zip.
      *
      * @param entries    Map of zip-entry name to bytes. Must not be empty.
      * @param crashType  The crash type string
@@ -89,16 +88,30 @@ class ReportUploader {
      * @return true if the upload succeeded
      */
     boolean upload(Map<String, byte[]> entries, String crashType, int crashTypeId) throws IOException {
+        return upload(entries, crashType, crashTypeId, null);
+    }
+
+    /**
+     * Upload multiple entries as a zip, with optional extra metadata fields
+     * included on the commitS3CrashUpload request (e.g. {@code user},
+     * {@code email}, {@code appKey}).
+     */
+    boolean upload(Map<String, byte[]> entries, String crashType, int crashTypeId,
+                   Map<String, String> extraCommitFields) throws IOException {
         if (entries == null || entries.isEmpty()) {
             throw new IllegalArgumentException("entries must not be empty");
         }
         byte[] zipped = createZip(entries);
-        // Use the first entry's name as the zip label for logging
         String zipName = entries.keySet().iterator().next();
-        return uploadZipped(zipped, zipName, crashType, crashTypeId);
+        return uploadZipped(zipped, zipName, crashType, crashTypeId, extraCommitFields);
     }
 
     private boolean uploadZipped(byte[] zipped, String fileName, String crashType, int crashTypeId) throws IOException {
+        return uploadZipped(zipped, fileName, crashType, crashTypeId, null);
+    }
+
+    private boolean uploadZipped(byte[] zipped, String fileName, String crashType, int crashTypeId,
+                                 Map<String, String> extraCommitFields) throws IOException {
         String md5 = md5Hex(zipped);
 
         // Step 1: Get presigned upload URL
@@ -117,7 +130,7 @@ class ReportUploader {
         Log.d(TAG, "Uploaded " + fileName + " to S3 (" + zipped.length + " bytes)");
 
         // Step 3: Commit
-        if (!commitUpload(presignedUrl, crashType, crashTypeId, md5)) {
+        if (!commitUpload(presignedUrl, crashType, crashTypeId, md5, extraCommitFields)) {
             Log.e(TAG, "Failed to commit upload");
             return false;
         }
@@ -187,7 +200,8 @@ class ReportUploader {
         }
     }
 
-    private boolean commitUpload(String s3Key, String crashType, int crashTypeId, String md5) throws IOException {
+    private boolean commitUpload(String s3Key, String crashType, int crashTypeId, String md5,
+                                 Map<String, String> extraFields) throws IOException {
         String urlStr = getBaseUrl() + "/api/commitS3CrashUpload";
         String boundary = java.util.UUID.randomUUID().toString();
 
@@ -205,8 +219,15 @@ class ReportUploader {
             writeField(baos, boundary, "appVersion", version);
             writeField(baos, boundary, "crashType", crashType);
             writeField(baos, boundary, "crashTypeId", String.valueOf(crashTypeId));
-            writeField(baos, boundary, "s3key", s3Key);
+            writeField(baos, boundary, "s3Key", s3Key);
             writeField(baos, boundary, "md5", md5);
+            if (extraFields != null) {
+                for (Map.Entry<String, String> e : extraFields.entrySet()) {
+                    if (e.getValue() != null && !e.getValue().isEmpty()) {
+                        writeField(baos, boundary, e.getKey(), e.getValue());
+                    }
+                }
+            }
             baos.write(("--" + boundary + "--\r\n").getBytes(StandardCharsets.UTF_8));
 
             byte[] payload = baos.toByteArray();

--- a/app/src/main/java/com/bugsplat/android/ReportUploader.java
+++ b/app/src/main/java/com/bugsplat/android/ReportUploader.java
@@ -5,10 +5,7 @@ import android.util.Log;
 import org.json.JSONObject;
 
 import java.io.BufferedReader;
-import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
-import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -17,7 +14,6 @@ import java.net.HttpURLConnection;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
-import java.util.Map;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
@@ -26,8 +22,14 @@ import java.util.zip.ZipOutputStream;
  * <ol>
  *   <li>GET /api/getCrashUploadUrl — obtain a presigned S3 URL</li>
  *   <li>PUT the zipped payload to the presigned URL</li>
- *   <li>POST /api/commitS3CrashUpload — commit with metadata</li>
+ *   <li>POST /api/commitS3CrashUpload — commit with metadata (see {@link CommitOptions})</li>
  * </ol>
+ *
+ * Callers are responsible for producing the zip. Use {@link #zip(String, byte[])}
+ * for the common single-entry case, or build a {@link ZipOutputStream} inline
+ * (e.g. to stream file attachments without reading them fully into memory).
+ *
+ * https://docs.bugsplat.com/introduction/development/web-services/crash
  */
 class ReportUploader {
     private static final String TAG = "BugSplat-Upload";
@@ -50,68 +52,16 @@ class ReportUploader {
     }
 
     /**
-     * Upload a file using the 3-part S3 upload flow.
+     * Upload a pre-built zip using the 3-part S3 upload flow.
      *
-     * @param file       The file to upload
-     * @param crashType  The crash type string (e.g. "Android.ANR", "User.Feedback")
-     * @param crashTypeId The crash type ID
-     * @return true if the upload succeeded
+     * @param zipped The zipped payload bytes to upload
+     * @param options Commit-request fields (crashType, user, email, attributes, etc.)
+     * @return true if all three steps succeeded
      */
-    boolean upload(File file, String crashType, int crashTypeId) throws IOException {
-        try (FileInputStream fis = new FileInputStream(file)) {
-            byte[] zipped = createZip(file.getName(), fis);
-            return uploadZipped(zipped, file.getName(), crashType, crashTypeId);
+    boolean upload(byte[] zipped, CommitOptions options) throws IOException {
+        if (zipped == null || zipped.length == 0) {
+            throw new IllegalArgumentException("zipped payload must not be empty");
         }
-    }
-
-    /**
-     * Upload raw bytes using the 3-part S3 upload flow.
-     *
-     * @param data       The data to upload
-     * @param fileName   The filename for the zip entry
-     * @param crashType  The crash type string (e.g. "Android.ANR", "User.Feedback")
-     * @param crashTypeId The crash type ID
-     * @return true if the upload succeeded
-     */
-    boolean upload(byte[] data, String fileName, String crashType, int crashTypeId) throws IOException {
-        byte[] zipped = createZip(fileName, new ByteArrayInputStream(data));
-        return uploadZipped(zipped, fileName, crashType, crashTypeId);
-    }
-
-    /**
-     * Upload multiple entries packed into a single zip using the 3-part S3 upload flow.
-     * Entries are added to the zip in the iteration order of {@code entries}.
-     *
-     * @param entries    Map of zip-entry name to bytes. Must not be empty.
-     * @param crashType  The crash type string
-     * @param crashTypeId The crash type ID
-     * @return true if the upload succeeded
-     */
-    boolean upload(Map<String, byte[]> entries, String crashType, int crashTypeId) throws IOException {
-        return upload(entries, crashType, crashTypeId, null);
-    }
-
-    /**
-     * Upload multiple entries as a zip, with optional extra metadata fields
-     * included on the commitS3CrashUpload request (e.g. {@code user},
-     * {@code email}, {@code appKey}).
-     */
-    boolean upload(Map<String, byte[]> entries, String crashType, int crashTypeId,
-                   Map<String, String> extraCommitFields) throws IOException {
-        if (entries == null || entries.isEmpty()) {
-            throw new IllegalArgumentException("entries must not be empty");
-        }
-        byte[] zipped = createZip(entries);
-        String zipName = entries.keySet().iterator().next();
-        return uploadZipped(zipped, zipName, crashType, crashTypeId, extraCommitFields);
-    }
-
-    private boolean uploadZipped(byte[] zipped, String fileName, String crashType, int crashTypeId) throws IOException {
-        return uploadZipped(zipped, fileName, crashType, crashTypeId, null);
-    }
-
-    private boolean uploadZipped(byte[] zipped, String fileName, String crashType, int crashTypeId,
-                                 Map<String, String> extraCommitFields) throws IOException {
         String md5 = md5Hex(zipped);
 
         // Step 1: Get presigned upload URL
@@ -120,22 +70,21 @@ class ReportUploader {
             Log.e(TAG, "Failed to get crash upload URL");
             return false;
         }
-        Log.d(TAG, "Got presigned URL for " + fileName);
 
         // Step 2: PUT the zip to S3
         if (!uploadToPresignedUrl(presignedUrl, zipped)) {
             Log.e(TAG, "Failed to upload to presigned URL");
             return false;
         }
-        Log.d(TAG, "Uploaded " + fileName + " to S3 (" + zipped.length + " bytes)");
+        Log.d(TAG, "Uploaded " + zipped.length + " bytes to S3");
 
         // Step 3: Commit
-        if (!commitUpload(presignedUrl, crashType, crashTypeId, md5, extraCommitFields)) {
+        if (!commitUpload(presignedUrl, md5, options)) {
             Log.e(TAG, "Failed to commit upload");
             return false;
         }
-        Log.i(TAG, "Upload committed: " + fileName + " (" + crashType + ")");
-
+        Log.i(TAG, "Upload committed"
+                + (options != null && options.crashType != null ? " (" + options.crashType + ")" : ""));
         return true;
     }
 
@@ -200,8 +149,12 @@ class ReportUploader {
         }
     }
 
-    private boolean commitUpload(String s3Key, String crashType, int crashTypeId, String md5,
-                                 Map<String, String> extraFields) throws IOException {
+    /**
+     * Build the multipart/form-data body for commitS3CrashUpload. Field names
+     * mirror the documented BugSplat API 1-to-1:
+     * https://docs.bugsplat.com/introduction/development/web-services/crash#request-body-multipart-form-data
+     */
+    private boolean commitUpload(String s3Key, String md5, CommitOptions options) throws IOException {
         String urlStr = getBaseUrl() + "/api/commitS3CrashUpload";
         String boundary = java.util.UUID.randomUUID().toString();
 
@@ -214,19 +167,31 @@ class ReportUploader {
             conn.setRequestProperty("Content-Type", "multipart/form-data; boundary=" + boundary);
 
             ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            // Fields always set by the uploader itself
             writeField(baos, boundary, "database", database);
             writeField(baos, boundary, "appName", application);
             writeField(baos, boundary, "appVersion", version);
-            writeField(baos, boundary, "crashType", crashType);
-            writeField(baos, boundary, "crashTypeId", String.valueOf(crashTypeId));
             writeField(baos, boundary, "s3Key", s3Key);
             writeField(baos, boundary, "md5", md5);
-            if (extraFields != null) {
-                for (Map.Entry<String, String> e : extraFields.entrySet()) {
-                    if (e.getValue() != null && !e.getValue().isEmpty()) {
-                        writeField(baos, boundary, e.getKey(), e.getValue());
-                    }
-                }
+
+            // Optional fields from CommitOptions — mirrors the documented
+            // commitS3CrashUpload multipart body 1-to-1.
+            if (options != null) {
+                writeOptionalField(baos, boundary, "crashType", options.crashType);
+                writeOptionalField(baos, boundary, "crashTypeId",
+                        options.crashTypeId != null ? options.crashTypeId.toString() : null);
+                writeOptionalField(baos, boundary, "fullDumpFlag",
+                        options.fullDumpFlag != null ? options.fullDumpFlag.toString() : null);
+                writeOptionalField(baos, boundary, "appKey", options.appKey);
+                writeOptionalField(baos, boundary, "description", options.description);
+                writeOptionalField(baos, boundary, "user", options.user);
+                writeOptionalField(baos, boundary, "email", options.email);
+                writeOptionalField(baos, boundary, "internalIP", options.internalIP);
+                writeOptionalField(baos, boundary, "notes", options.notes);
+                writeOptionalField(baos, boundary, "processor", options.processor);
+                writeOptionalField(baos, boundary, "crashTime", options.crashTime);
+                writeOptionalField(baos, boundary, "attributes", options.attributesJson());
+                writeOptionalField(baos, boundary, "crashHash", options.crashHash);
             }
             baos.write(("--" + boundary + "--\r\n").getBytes(StandardCharsets.UTF_8));
 
@@ -254,33 +219,13 @@ class ReportUploader {
 
     // -- Utilities --
 
-    /**
-     * Create a zip containing a single entry. Does not close {@code data};
-     * callers are responsible for closing it.
-     */
-    static byte[] createZip(String entryName, InputStream data) throws IOException {
+    /** Convenience: build a single-entry zip around {@code data}. */
+    static byte[] zip(String entryName, byte[] data) throws IOException {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         try (ZipOutputStream zos = new ZipOutputStream(baos)) {
             zos.putNextEntry(new ZipEntry(entryName));
-            byte[] buffer = new byte[4096];
-            int bytesRead;
-            while ((bytesRead = data.read(buffer)) != -1) {
-                zos.write(buffer, 0, bytesRead);
-            }
+            zos.write(data);
             zos.closeEntry();
-        }
-        return baos.toByteArray();
-    }
-
-    /** Create a zip containing multiple entries (name → bytes). */
-    static byte[] createZip(Map<String, byte[]> entries) throws IOException {
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        try (ZipOutputStream zos = new ZipOutputStream(baos)) {
-            for (Map.Entry<String, byte[]> entry : entries.entrySet()) {
-                zos.putNextEntry(new ZipEntry(entry.getKey()));
-                zos.write(entry.getValue());
-                zos.closeEntry();
-            }
         }
         return baos.toByteArray();
     }
@@ -319,12 +264,18 @@ class ReportUploader {
         baos.write("\r\n".getBytes(StandardCharsets.UTF_8));
     }
 
+    private static void writeOptionalField(ByteArrayOutputStream baos, String boundary,
+                                           String name, String value) throws IOException {
+        if (value != null && !value.isEmpty()) {
+            writeField(baos, boundary, name, value);
+        }
+    }
+
     private static String urlEncode(String value) {
         try {
             return java.net.URLEncoder.encode(value, "UTF-8");
         } catch (java.io.UnsupportedEncodingException e) {
-            // UTF-8 is always supported.
-            throw new AssertionError(e);
+            throw new AssertionError(e); // UTF-8 always supported
         }
     }
 }

--- a/app/src/test/java/com/bugsplat/android/FeedbackClientTest.java
+++ b/app/src/test/java/com/bugsplat/android/FeedbackClientTest.java
@@ -156,7 +156,7 @@ public class FeedbackClientTest {
     }
 
     @Test
-    public void postFeedback_withAttachments_includesAttachmentInfo() throws Exception {
+    public void postFeedback_withAttachments_uploadsAttachmentAsZipEntry() throws Exception {
         enqueueSuccessfulUpload();
 
         File tempFile = File.createTempFile("test_attachment", ".txt");
@@ -172,8 +172,16 @@ public class FeedbackClientTest {
         server.takeRequest();
         RecordedRequest putRequest = server.takeRequest();
 
-        String content = extractZipContent(putRequest.getBody().readByteArray(), "feedback.txt");
-        assertTrue("should contain attachment info", content.contains("Attachment: " + tempFile.getName()));
+        // The attachment should be uploaded as its own zip entry alongside feedback.txt
+        byte[] zipData = putRequest.getBody().readByteArray();
+        String attachmentContent = extractZipContent(zipData, tempFile.getName());
+        assertEquals("attachment content", attachmentContent);
+
+        // feedback.txt should still exist but should NOT contain the old
+        // "Attachment: filename" text (attachments are now real zip entries).
+        String feedbackTxt = extractZipContent(zipData, "feedback.txt");
+        assertFalse("feedback.txt should not contain stale Attachment: line",
+                feedbackTxt.contains("Attachment:"));
 
         tempFile.delete();
     }

--- a/app/src/test/java/com/bugsplat/android/FeedbackClientTest.java
+++ b/app/src/test/java/com/bugsplat/android/FeedbackClientTest.java
@@ -1,0 +1,200 @@
+package com.bugsplat.android;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+
+import static org.junit.Assert.*;
+
+public class FeedbackClientTest {
+
+    private MockWebServer server;
+
+    @Before
+    public void setUp() throws IOException {
+        server = new MockWebServer();
+        server.start();
+    }
+
+    @After
+    public void tearDown() throws IOException {
+        server.shutdown();
+    }
+
+    private FeedbackClient createClient() {
+        ReportUploader uploader = new ReportUploader("testdb", "testapp", "1.0.0") {
+            @Override
+            String getBaseUrl() {
+                return server.url("").toString();
+            }
+        };
+        return new FeedbackClient("testdb", "testapp", "1.0.0", uploader);
+    }
+
+    private void enqueueSuccessfulUpload() {
+        String presignedUrl = server.url("/s3-upload").toString();
+        server.enqueue(new MockResponse().setResponseCode(200)
+                .setBody("{\"url\": \"" + presignedUrl + "\"}"));
+        server.enqueue(new MockResponse().setResponseCode(200));
+        server.enqueue(new MockResponse().setResponseCode(200));
+    }
+
+    @Test
+    public void postFeedback_includesAllFieldsInReport() throws Exception {
+        enqueueSuccessfulUpload();
+
+        FeedbackClient client = createClient();
+        boolean result = client.postFeedback("Bug Report", "App crashed on login", "alice", "alice@test.com", "key123");
+
+        assertTrue(result);
+
+        // Skip step 1 (getCrashUploadUrl), inspect step 2 (S3 PUT) for the content
+        server.takeRequest(); // getCrashUploadUrl
+        RecordedRequest putRequest = server.takeRequest();
+
+        String content = extractZipContent(putRequest.getBody().readByteArray(), "feedback.txt");
+        assertTrue("should contain title", content.contains("Title: Bug Report"));
+        assertTrue("should contain description", content.contains("Description: App crashed on login"));
+        assertTrue("should contain user", content.contains("User: alice"));
+        assertTrue("should contain email", content.contains("Email: alice@test.com"));
+        assertTrue("should contain appKey", content.contains("AppKey: key123"));
+    }
+
+    @Test
+    public void postFeedback_omitsNullOptionalFields() throws Exception {
+        enqueueSuccessfulUpload();
+
+        FeedbackClient client = createClient();
+        boolean result = client.postFeedback("Bug Report", null, null, null, null);
+
+        assertTrue(result);
+
+        server.takeRequest();
+        RecordedRequest putRequest = server.takeRequest();
+
+        String content = extractZipContent(putRequest.getBody().readByteArray(), "feedback.txt");
+        assertTrue("should contain title", content.contains("Title: Bug Report"));
+        assertFalse("should not contain Description:", content.contains("Description:"));
+        assertFalse("should not contain User:", content.contains("User:"));
+        assertFalse("should not contain Email:", content.contains("Email:"));
+        assertFalse("should not contain AppKey:", content.contains("AppKey:"));
+    }
+
+    @Test
+    public void postFeedback_omitsEmptyOptionalFields() throws Exception {
+        enqueueSuccessfulUpload();
+
+        FeedbackClient client = createClient();
+        boolean result = client.postFeedback("Bug Report", "", "", "", "");
+
+        assertTrue(result);
+
+        server.takeRequest();
+        RecordedRequest putRequest = server.takeRequest();
+
+        String content = extractZipContent(putRequest.getBody().readByteArray(), "feedback.txt");
+        assertTrue("should contain title", content.contains("Title: Bug Report"));
+        assertFalse("should not contain Description:", content.contains("Description:"));
+        assertFalse("should not contain User:", content.contains("User:"));
+        assertFalse("should not contain Email:", content.contains("Email:"));
+        assertFalse("should not contain AppKey:", content.contains("AppKey:"));
+    }
+
+    @Test
+    public void postFeedback_handlesNullTitle() throws Exception {
+        enqueueSuccessfulUpload();
+
+        FeedbackClient client = createClient();
+        boolean result = client.postFeedback(null, "some description", null, null, null);
+
+        assertTrue(result);
+
+        server.takeRequest();
+        RecordedRequest putRequest = server.takeRequest();
+
+        String content = extractZipContent(putRequest.getBody().readByteArray(), "feedback.txt");
+        assertTrue("should contain empty title", content.contains("Title: \n"));
+    }
+
+    @Test
+    public void postFeedback_commitUsesCorrectCrashType() throws Exception {
+        enqueueSuccessfulUpload();
+
+        FeedbackClient client = createClient();
+        client.postFeedback("Test", null, null, null, null);
+
+        server.takeRequest(); // getCrashUploadUrl
+        server.takeRequest(); // S3 PUT
+        RecordedRequest commitRequest = server.takeRequest();
+
+        String body = commitRequest.getBody().readUtf8();
+        assertTrue("should use UserFeedback crash type", body.contains("UserFeedback"));
+        assertTrue("should use crash type id 36", body.contains("36"));
+    }
+
+    @Test
+    public void postFeedback_returnsFalseOnUploadFailure() throws Exception {
+        server.enqueue(new MockResponse().setResponseCode(500));
+
+        FeedbackClient client = createClient();
+        boolean result = client.postFeedback("Test", null, null, null, null);
+
+        assertFalse(result);
+    }
+
+    @Test
+    public void postFeedback_withAttachments_includesAttachmentInfo() throws Exception {
+        enqueueSuccessfulUpload();
+
+        File tempFile = File.createTempFile("test_attachment", ".txt");
+        try (FileWriter writer = new FileWriter(tempFile)) {
+            writer.write("attachment content");
+        }
+
+        FeedbackClient client = createClient();
+        boolean result = client.postFeedback("Bug", "desc", null, null, null, Collections.singletonList(tempFile));
+
+        assertTrue(result);
+
+        server.takeRequest();
+        RecordedRequest putRequest = server.takeRequest();
+
+        String content = extractZipContent(putRequest.getBody().readByteArray(), "feedback.txt");
+        assertTrue("should contain attachment info", content.contains("Attachment: " + tempFile.getName()));
+
+        tempFile.delete();
+    }
+
+    private String extractZipContent(byte[] zipData, String entryName) throws IOException {
+        ZipInputStream zis = new ZipInputStream(new ByteArrayInputStream(zipData));
+        ZipEntry entry;
+        while ((entry = zis.getNextEntry()) != null) {
+            if (entry.getName().equals(entryName)) {
+                byte[] buffer = new byte[4096];
+                StringBuilder sb = new StringBuilder();
+                int len;
+                while ((len = zis.read(buffer)) != -1) {
+                    sb.append(new String(buffer, 0, len, "UTF-8"));
+                }
+                zis.close();
+                return sb.toString();
+            }
+        }
+        zis.close();
+        fail("zip entry '" + entryName + "' not found");
+        return null;
+    }
+}

--- a/app/src/test/java/com/bugsplat/android/FeedbackClientTest.java
+++ b/app/src/test/java/com/bugsplat/android/FeedbackClientTest.java
@@ -1,5 +1,6 @@
 package com.bugsplat.android;
 
+import org.json.JSONObject;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -8,7 +9,6 @@ import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
@@ -38,7 +38,8 @@ public class FeedbackClientTest {
         ReportUploader uploader = new ReportUploader("testdb", "testapp", "1.0.0") {
             @Override
             String getBaseUrl() {
-                return server.url("").toString();
+                String url = server.url("").toString();
+                return url.endsWith("/") ? url.substring(0, url.length() - 1) : url;
             }
         };
         return new FeedbackClient("testdb", "testapp", "1.0.0", uploader);
@@ -53,84 +54,56 @@ public class FeedbackClientTest {
     }
 
     @Test
-    public void postFeedback_includesAllFieldsInReport() throws Exception {
+    public void feedbackBodyIsJson_withTitleAndDescription() throws Exception {
         enqueueSuccessfulUpload();
 
         FeedbackClient client = createClient();
-        boolean result = client.postFeedback("Bug Report", "App crashed on login", "alice", "alice@test.com", "key123");
+        boolean result = client.postFeedback("Bug Report", "App crashed on login", null, null, null);
 
         assertTrue(result);
 
-        // Skip step 1 (getCrashUploadUrl), inspect step 2 (S3 PUT) for the content
         server.takeRequest(); // getCrashUploadUrl
         RecordedRequest putRequest = server.takeRequest();
 
-        String content = extractZipContent(putRequest.getBody().readByteArray(), "feedback.txt");
-        assertTrue("should contain title", content.contains("Title: Bug Report"));
-        assertTrue("should contain description", content.contains("Description: App crashed on login"));
-        assertTrue("should contain user", content.contains("User: alice"));
-        assertTrue("should contain email", content.contains("Email: alice@test.com"));
-        assertTrue("should contain appKey", content.contains("AppKey: key123"));
+        String json = extractZipContent(putRequest.getBody().readByteArray(), "feedback.json");
+        JSONObject parsed = new JSONObject(json);
+        assertEquals("Bug Report", parsed.getString("title"));
+        assertEquals("App crashed on login", parsed.getString("description"));
     }
 
     @Test
-    public void postFeedback_omitsNullOptionalFields() throws Exception {
+    public void feedbackBody_omitsDescriptionWhenNullOrEmpty() throws Exception {
         enqueueSuccessfulUpload();
 
         FeedbackClient client = createClient();
-        boolean result = client.postFeedback("Bug Report", null, null, null, null);
-
-        assertTrue(result);
+        client.postFeedback("Bug Report", null, null, null, null);
 
         server.takeRequest();
         RecordedRequest putRequest = server.takeRequest();
 
-        String content = extractZipContent(putRequest.getBody().readByteArray(), "feedback.txt");
-        assertTrue("should contain title", content.contains("Title: Bug Report"));
-        assertFalse("should not contain Description:", content.contains("Description:"));
-        assertFalse("should not contain User:", content.contains("User:"));
-        assertFalse("should not contain Email:", content.contains("Email:"));
-        assertFalse("should not contain AppKey:", content.contains("AppKey:"));
+        String json = extractZipContent(putRequest.getBody().readByteArray(), "feedback.json");
+        JSONObject parsed = new JSONObject(json);
+        assertEquals("Bug Report", parsed.getString("title"));
+        assertFalse("should not include description when null", parsed.has("description"));
     }
 
     @Test
-    public void postFeedback_omitsEmptyOptionalFields() throws Exception {
+    public void feedbackBody_handlesNullTitleAsEmptyString() throws Exception {
         enqueueSuccessfulUpload();
 
         FeedbackClient client = createClient();
-        boolean result = client.postFeedback("Bug Report", "", "", "", "");
-
-        assertTrue(result);
+        client.postFeedback(null, "desc", null, null, null);
 
         server.takeRequest();
         RecordedRequest putRequest = server.takeRequest();
 
-        String content = extractZipContent(putRequest.getBody().readByteArray(), "feedback.txt");
-        assertTrue("should contain title", content.contains("Title: Bug Report"));
-        assertFalse("should not contain Description:", content.contains("Description:"));
-        assertFalse("should not contain User:", content.contains("User:"));
-        assertFalse("should not contain Email:", content.contains("Email:"));
-        assertFalse("should not contain AppKey:", content.contains("AppKey:"));
+        String json = extractZipContent(putRequest.getBody().readByteArray(), "feedback.json");
+        JSONObject parsed = new JSONObject(json);
+        assertEquals("", parsed.getString("title"));
     }
 
     @Test
-    public void postFeedback_handlesNullTitle() throws Exception {
-        enqueueSuccessfulUpload();
-
-        FeedbackClient client = createClient();
-        boolean result = client.postFeedback(null, "some description", null, null, null);
-
-        assertTrue(result);
-
-        server.takeRequest();
-        RecordedRequest putRequest = server.takeRequest();
-
-        String content = extractZipContent(putRequest.getBody().readByteArray(), "feedback.txt");
-        assertTrue("should contain empty title", content.contains("Title: \n"));
-    }
-
-    @Test
-    public void postFeedback_commitUsesCorrectCrashType() throws Exception {
+    public void commitRequest_usesUserDotFeedbackCrashType() throws Exception {
         enqueueSuccessfulUpload();
 
         FeedbackClient client = createClient();
@@ -141,8 +114,67 @@ public class FeedbackClientTest {
         RecordedRequest commitRequest = server.takeRequest();
 
         String body = commitRequest.getBody().readUtf8();
-        assertTrue("should use UserFeedback crash type", body.contains("UserFeedback"));
+        assertTrue("should use User.Feedback crash type", body.contains("User.Feedback"));
         assertTrue("should use crash type id 36", body.contains("36"));
+    }
+
+    @Test
+    public void commitRequest_includesOptionalUserEmailAppKey() throws Exception {
+        enqueueSuccessfulUpload();
+
+        FeedbackClient client = createClient();
+        client.postFeedback("Title", "some desc", "alice", "alice@test.com", "key123");
+
+        server.takeRequest();
+        server.takeRequest();
+        RecordedRequest commitRequest = server.takeRequest();
+
+        String body = commitRequest.getBody().readUtf8();
+        assertTrue("commit should include user", body.contains("alice"));
+        assertTrue("commit should include email", body.contains("alice@test.com"));
+        assertTrue("commit should include appKey", body.contains("key123"));
+        // description is mirrored on the commit (per User Feedback API docs)
+        assertTrue("commit should include description", body.contains("some desc"));
+    }
+
+    @Test
+    public void commitRequest_includesAttributesAsJsonString() throws Exception {
+        enqueueSuccessfulUpload();
+
+        java.util.Map<String, String> attributes = new java.util.LinkedHashMap<>();
+        attributes.put("env", "prod");
+        attributes.put("tier", "premium");
+
+        FeedbackClient client = createClient();
+        client.postFeedback("Title", null, null, null, null, null, attributes);
+
+        server.takeRequest();
+        server.takeRequest();
+        RecordedRequest commitRequest = server.takeRequest();
+
+        String body = commitRequest.getBody().readUtf8();
+        // The attributes field is a JSON string (per the commit API docs).
+        assertTrue("commit should include attributes field", body.contains("name=\"attributes\""));
+        assertTrue("commit attributes should be JSON-encoded", body.contains("\"env\":\"prod\""));
+        assertTrue("commit attributes should include tier", body.contains("\"tier\":\"premium\""));
+    }
+
+    @Test
+    public void commitRequest_omitsOptionalFieldsWhenNullOrEmpty() throws Exception {
+        enqueueSuccessfulUpload();
+
+        FeedbackClient client = createClient();
+        client.postFeedback("Title", null, null, null, null);
+
+        server.takeRequest();
+        server.takeRequest();
+        RecordedRequest commitRequest = server.takeRequest();
+
+        String body = commitRequest.getBody().readUtf8();
+        assertFalse("should not include user field", body.contains("name=\"user\""));
+        assertFalse("should not include email field", body.contains("name=\"email\""));
+        assertFalse("should not include appKey field", body.contains("name=\"appKey\""));
+        assertFalse("should not include attributes field", body.contains("name=\"attributes\""));
     }
 
     @Test
@@ -172,16 +204,14 @@ public class FeedbackClientTest {
         server.takeRequest();
         RecordedRequest putRequest = server.takeRequest();
 
-        // The attachment should be uploaded as its own zip entry alongside feedback.txt
         byte[] zipData = putRequest.getBody().readByteArray();
         String attachmentContent = extractZipContent(zipData, tempFile.getName());
         assertEquals("attachment content", attachmentContent);
 
-        // feedback.txt should still exist but should NOT contain the old
-        // "Attachment: filename" text (attachments are now real zip entries).
-        String feedbackTxt = extractZipContent(zipData, "feedback.txt");
-        assertFalse("feedback.txt should not contain stale Attachment: line",
-                feedbackTxt.contains("Attachment:"));
+        // feedback.json should still be valid JSON with just title/description
+        String json = extractZipContent(zipData, "feedback.json");
+        JSONObject parsed = new JSONObject(json);
+        assertEquals("Bug", parsed.getString("title"));
 
         tempFile.delete();
     }

--- a/app/src/test/java/com/bugsplat/android/ReportUploaderTest.java
+++ b/app/src/test/java/com/bugsplat/android/ReportUploaderTest.java
@@ -316,11 +316,10 @@ public class ReportUploaderTest {
 
         TestableReportUploader(String database, String application, String version, MockWebServer server) {
             super(database, application, version);
-            this.baseUrl = server.url("").toString();
-            // Remove trailing slash
-            if (this.baseUrl.endsWith("/")) {
-                // baseUrl is fine as-is, we'll override the URL construction
-            }
+            // MockWebServer URLs include a trailing slash; strip it since
+            // ReportUploader appends paths starting with "/".
+            String url = server.url("").toString();
+            this.baseUrl = url.endsWith("/") ? url.substring(0, url.length() - 1) : url;
         }
 
         @Override

--- a/app/src/test/java/com/bugsplat/android/ReportUploaderTest.java
+++ b/app/src/test/java/com/bugsplat/android/ReportUploaderTest.java
@@ -1,0 +1,331 @@
+package com.bugsplat.android;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+
+import static org.junit.Assert.*;
+
+public class ReportUploaderTest {
+
+    // ---- createZip tests ----
+
+    @Test
+    public void createZip_producesValidZipWithCorrectEntry() throws IOException {
+        String content = "hello world";
+        byte[] zipped = ReportUploader.createZip(
+                "test.txt",
+                new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8))
+        );
+
+        assertNotNull(zipped);
+        assertTrue(zipped.length > 0);
+
+        // Read back the zip and verify
+        ZipInputStream zis = new ZipInputStream(new ByteArrayInputStream(zipped));
+        ZipEntry entry = zis.getNextEntry();
+        assertNotNull("zip should contain an entry", entry);
+        assertEquals("test.txt", entry.getName());
+
+        // Verify content
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        byte[] buffer = new byte[1024];
+        int len;
+        while ((len = zis.read(buffer)) != -1) {
+            baos.write(buffer, 0, len);
+        }
+        assertEquals(content, baos.toString("UTF-8"));
+
+        // Should be only one entry
+        assertNull("zip should contain exactly one entry", zis.getNextEntry());
+        zis.close();
+    }
+
+    @Test
+    public void createZip_handlesEmptyInput() throws IOException {
+        byte[] zipped = ReportUploader.createZip(
+                "empty.txt",
+                new ByteArrayInputStream(new byte[0])
+        );
+
+        assertNotNull(zipped);
+
+        ZipInputStream zis = new ZipInputStream(new ByteArrayInputStream(zipped));
+        ZipEntry entry = zis.getNextEntry();
+        assertNotNull(entry);
+        assertEquals("empty.txt", entry.getName());
+
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        byte[] buffer = new byte[1024];
+        int len;
+        while ((len = zis.read(buffer)) != -1) {
+            baos.write(buffer, 0, len);
+        }
+        assertEquals(0, baos.size());
+        zis.close();
+    }
+
+    @Test
+    public void createZip_handlesLargeInput() throws IOException {
+        byte[] largeContent = new byte[100_000];
+        for (int i = 0; i < largeContent.length; i++) {
+            largeContent[i] = (byte) (i % 256);
+        }
+
+        byte[] zipped = ReportUploader.createZip(
+                "large.bin",
+                new ByteArrayInputStream(largeContent)
+        );
+
+        // Zip should be smaller due to compression of repeating pattern
+        assertNotNull(zipped);
+
+        ZipInputStream zis = new ZipInputStream(new ByteArrayInputStream(zipped));
+        ZipEntry entry = zis.getNextEntry();
+        assertNotNull(entry);
+
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        byte[] buffer = new byte[4096];
+        int len;
+        while ((len = zis.read(buffer)) != -1) {
+            baos.write(buffer, 0, len);
+        }
+        assertArrayEquals(largeContent, baos.toByteArray());
+        zis.close();
+    }
+
+    // ---- md5Hex tests ----
+
+    @Test
+    public void md5Hex_returnsCorrectHashForKnownInput() {
+        // MD5 of "hello world" is 5eb63bbbe01eeed093cb22bb8f5acdc3
+        String hash = ReportUploader.md5Hex("hello world".getBytes(StandardCharsets.UTF_8));
+        assertEquals("5eb63bbbe01eeed093cb22bb8f5acdc3", hash);
+    }
+
+    @Test
+    public void md5Hex_returnsCorrectHashForEmptyInput() {
+        // MD5 of empty string is d41d8cd98f00b204e9800998ecf8427e
+        String hash = ReportUploader.md5Hex(new byte[0]);
+        assertEquals("d41d8cd98f00b204e9800998ecf8427e", hash);
+    }
+
+    @Test
+    public void md5Hex_returns32CharLowercaseHex() {
+        String hash = ReportUploader.md5Hex("test data".getBytes(StandardCharsets.UTF_8));
+        assertEquals(32, hash.length());
+        assertTrue("hash should be lowercase hex", hash.matches("[0-9a-f]+"));
+    }
+
+    // ---- readBody tests ----
+
+    @Test
+    public void readBody_readsInputStream() throws IOException {
+        String content = "response body content";
+        InputStream stream = new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8));
+        assertEquals(content, ReportUploader.readBody(stream));
+    }
+
+    @Test
+    public void readBody_returnsEmptyForNullStream() throws IOException {
+        assertEquals("", ReportUploader.readBody(null));
+    }
+
+    @Test
+    public void readBody_handlesEmptyStream() throws IOException {
+        InputStream stream = new ByteArrayInputStream(new byte[0]);
+        assertEquals("", ReportUploader.readBody(stream));
+    }
+
+    // ---- 3-step upload integration tests ----
+
+    private MockWebServer server;
+
+    @Before
+    public void setUp() throws IOException {
+        server = new MockWebServer();
+        server.start();
+    }
+
+    @After
+    public void tearDown() throws IOException {
+        server.shutdown();
+    }
+
+    @Test
+    public void upload_performsThreeStepFlow() throws Exception {
+        String presignedUrl = server.url("/s3-upload").toString();
+
+        // Step 1: getCrashUploadUrl response
+        server.enqueue(new MockResponse()
+                .setResponseCode(200)
+                .setBody("{\"url\": \"" + presignedUrl + "\"}"));
+
+        // Step 2: S3 PUT response
+        server.enqueue(new MockResponse().setResponseCode(200));
+
+        // Step 3: commitS3CrashUpload response
+        server.enqueue(new MockResponse().setResponseCode(200));
+
+        // Use a ReportUploader that points at our mock server
+        String baseUrl = server.url("").toString();
+        // We need to extract host:port to construct the uploader
+        // The uploader constructs URLs like https://{database}.bugsplat.com/...
+        // So we'll use a TestableReportUploader subclass approach
+        // Actually, let's test the utility methods above and the flow separately
+
+        // For the full flow test, we verify the 3 requests arrive in order
+        ReportUploader uploader = new TestableReportUploader("testdb", "testapp", "1.0.0", server);
+        boolean result = uploader.upload(
+                "test content".getBytes(StandardCharsets.UTF_8),
+                "test.txt",
+                "Android ANR",
+                37
+        );
+
+        assertTrue("upload should succeed", result);
+        assertEquals("should make 3 requests", 3, server.getRequestCount());
+
+        // Verify Step 1: getCrashUploadUrl
+        RecordedRequest req1 = server.takeRequest();
+        assertEquals("GET", req1.getMethod());
+        assertTrue(req1.getPath().contains("getCrashUploadUrl"));
+        assertTrue(req1.getPath().contains("database=testdb"));
+        assertTrue(req1.getPath().contains("appName=testapp"));
+        assertTrue(req1.getPath().contains("appVersion=1.0.0"));
+
+        // Verify Step 2: S3 PUT
+        RecordedRequest req2 = server.takeRequest();
+        assertEquals("PUT", req2.getMethod());
+        assertEquals("application/octet-stream", req2.getHeader("Content-Type"));
+
+        // Verify the body is a valid zip
+        byte[] putBody = req2.getBody().readByteArray();
+        ZipInputStream zis = new ZipInputStream(new ByteArrayInputStream(putBody));
+        ZipEntry entry = zis.getNextEntry();
+        assertNotNull(entry);
+        assertEquals("test.txt", entry.getName());
+        zis.close();
+
+        // Verify Step 3: commitS3CrashUpload
+        RecordedRequest req3 = server.takeRequest();
+        assertEquals("POST", req3.getMethod());
+        assertTrue(req3.getPath().contains("commitS3CrashUpload"));
+        String commitBody = req3.getBody().readUtf8();
+        assertTrue("should contain database", commitBody.contains("testdb"));
+        assertTrue("should contain appName", commitBody.contains("testapp"));
+        assertTrue("should contain appVersion", commitBody.contains("1.0.0"));
+        assertTrue("should contain crashType", commitBody.contains("Android ANR"));
+        assertTrue("should contain crashTypeId", commitBody.contains("37"));
+        assertTrue("should contain md5", commitBody.contains("md5"));
+    }
+
+    @Test
+    public void upload_returnsFalseWhenGetUrlFails() throws Exception {
+        server.enqueue(new MockResponse().setResponseCode(500));
+
+        ReportUploader uploader = new TestableReportUploader("testdb", "testapp", "1.0.0", server);
+        boolean result = uploader.upload(
+                "test".getBytes(StandardCharsets.UTF_8),
+                "test.txt",
+                "Android ANR",
+                37
+        );
+
+        assertFalse("upload should fail when getCrashUploadUrl fails", result);
+        assertEquals(1, server.getRequestCount());
+    }
+
+    @Test
+    public void upload_returnsFalseWhenRateLimited() throws Exception {
+        server.enqueue(new MockResponse().setResponseCode(429));
+
+        ReportUploader uploader = new TestableReportUploader("testdb", "testapp", "1.0.0", server);
+        boolean result = uploader.upload(
+                "test".getBytes(StandardCharsets.UTF_8),
+                "test.txt",
+                "Android ANR",
+                37
+        );
+
+        assertFalse("upload should fail when rate limited", result);
+    }
+
+    @Test
+    public void upload_returnsFalseWhenS3PutFails() throws Exception {
+        String presignedUrl = server.url("/s3-upload").toString();
+
+        server.enqueue(new MockResponse()
+                .setResponseCode(200)
+                .setBody("{\"url\": \"" + presignedUrl + "\"}"));
+        server.enqueue(new MockResponse().setResponseCode(403));
+
+        ReportUploader uploader = new TestableReportUploader("testdb", "testapp", "1.0.0", server);
+        boolean result = uploader.upload(
+                "test".getBytes(StandardCharsets.UTF_8),
+                "test.txt",
+                "Android ANR",
+                37
+        );
+
+        assertFalse("upload should fail when S3 PUT fails", result);
+        assertEquals(2, server.getRequestCount());
+    }
+
+    @Test
+    public void upload_returnsFalseWhenCommitFails() throws Exception {
+        String presignedUrl = server.url("/s3-upload").toString();
+
+        server.enqueue(new MockResponse()
+                .setResponseCode(200)
+                .setBody("{\"url\": \"" + presignedUrl + "\"}"));
+        server.enqueue(new MockResponse().setResponseCode(200));
+        server.enqueue(new MockResponse().setResponseCode(500));
+
+        ReportUploader uploader = new TestableReportUploader("testdb", "testapp", "1.0.0", server);
+        boolean result = uploader.upload(
+                "test".getBytes(StandardCharsets.UTF_8),
+                "test.txt",
+                "Android ANR",
+                37
+        );
+
+        assertFalse("upload should fail when commit fails", result);
+        assertEquals(3, server.getRequestCount());
+    }
+
+    /**
+     * Test subclass that routes all HTTP calls to the MockWebServer
+     * instead of the real BugSplat API.
+     */
+    static class TestableReportUploader extends ReportUploader {
+        private final String baseUrl;
+
+        TestableReportUploader(String database, String application, String version, MockWebServer server) {
+            super(database, application, version);
+            this.baseUrl = server.url("").toString();
+            // Remove trailing slash
+            if (this.baseUrl.endsWith("/")) {
+                // baseUrl is fine as-is, we'll override the URL construction
+            }
+        }
+
+        @Override
+        String getBaseUrl() {
+            return baseUrl;
+        }
+    }
+}

--- a/app/src/test/java/com/bugsplat/android/ReportUploaderTest.java
+++ b/app/src/test/java/com/bugsplat/android/ReportUploaderTest.java
@@ -9,7 +9,8 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
-import java.security.MessageDigest;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
@@ -21,89 +22,41 @@ import static org.junit.Assert.*;
 
 public class ReportUploaderTest {
 
-    // ---- createZip tests ----
+    // ---- zip tests ----
 
     @Test
-    public void createZip_producesValidZipWithCorrectEntry() throws IOException {
+    public void zip_producesValidSingleEntryZip() throws IOException {
         String content = "hello world";
-        byte[] zipped = ReportUploader.createZip(
-                "test.txt",
-                new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8))
-        );
+        byte[] zipped = ReportUploader.zip("test.txt", content.getBytes(StandardCharsets.UTF_8));
 
         assertNotNull(zipped);
         assertTrue(zipped.length > 0);
 
-        // Read back the zip and verify
         ZipInputStream zis = new ZipInputStream(new ByteArrayInputStream(zipped));
         ZipEntry entry = zis.getNextEntry();
-        assertNotNull("zip should contain an entry", entry);
+        assertNotNull(entry);
         assertEquals("test.txt", entry.getName());
 
-        // Verify content
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         byte[] buffer = new byte[1024];
         int len;
         while ((len = zis.read(buffer)) != -1) {
             baos.write(buffer, 0, len);
         }
-        assertEquals(content, baos.toString("UTF-8"));
+        assertEquals(content, new String(baos.toByteArray(), StandardCharsets.UTF_8));
 
-        // Should be only one entry
-        assertNull("zip should contain exactly one entry", zis.getNextEntry());
+        assertNull(zis.getNextEntry());
         zis.close();
     }
 
     @Test
-    public void createZip_handlesEmptyInput() throws IOException {
-        byte[] zipped = ReportUploader.createZip(
-                "empty.txt",
-                new ByteArrayInputStream(new byte[0])
-        );
-
-        assertNotNull(zipped);
+    public void zip_handlesEmptyInput() throws IOException {
+        byte[] zipped = ReportUploader.zip("empty.txt", new byte[0]);
 
         ZipInputStream zis = new ZipInputStream(new ByteArrayInputStream(zipped));
         ZipEntry entry = zis.getNextEntry();
         assertNotNull(entry);
         assertEquals("empty.txt", entry.getName());
-
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        byte[] buffer = new byte[1024];
-        int len;
-        while ((len = zis.read(buffer)) != -1) {
-            baos.write(buffer, 0, len);
-        }
-        assertEquals(0, baos.size());
-        zis.close();
-    }
-
-    @Test
-    public void createZip_handlesLargeInput() throws IOException {
-        byte[] largeContent = new byte[100_000];
-        for (int i = 0; i < largeContent.length; i++) {
-            largeContent[i] = (byte) (i % 256);
-        }
-
-        byte[] zipped = ReportUploader.createZip(
-                "large.bin",
-                new ByteArrayInputStream(largeContent)
-        );
-
-        // Zip should be smaller due to compression of repeating pattern
-        assertNotNull(zipped);
-
-        ZipInputStream zis = new ZipInputStream(new ByteArrayInputStream(zipped));
-        ZipEntry entry = zis.getNextEntry();
-        assertNotNull(entry);
-
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        byte[] buffer = new byte[4096];
-        int len;
-        while ((len = zis.read(buffer)) != -1) {
-            baos.write(buffer, 0, len);
-        }
-        assertArrayEquals(largeContent, baos.toByteArray());
         zis.close();
     }
 
@@ -111,23 +64,20 @@ public class ReportUploaderTest {
 
     @Test
     public void md5Hex_returnsCorrectHashForKnownInput() {
-        // MD5 of "hello world" is 5eb63bbbe01eeed093cb22bb8f5acdc3
         String hash = ReportUploader.md5Hex("hello world".getBytes(StandardCharsets.UTF_8));
         assertEquals("5eb63bbbe01eeed093cb22bb8f5acdc3", hash);
     }
 
     @Test
     public void md5Hex_returnsCorrectHashForEmptyInput() {
-        // MD5 of empty string is d41d8cd98f00b204e9800998ecf8427e
-        String hash = ReportUploader.md5Hex(new byte[0]);
-        assertEquals("d41d8cd98f00b204e9800998ecf8427e", hash);
+        assertEquals("d41d8cd98f00b204e9800998ecf8427e", ReportUploader.md5Hex(new byte[0]));
     }
 
     @Test
     public void md5Hex_returns32CharLowercaseHex() {
         String hash = ReportUploader.md5Hex("test data".getBytes(StandardCharsets.UTF_8));
         assertEquals(32, hash.length());
-        assertTrue("hash should be lowercase hex", hash.matches("[0-9a-f]+"));
+        assertTrue(hash.matches("[0-9a-f]+"));
     }
 
     // ---- readBody tests ----
@@ -146,8 +96,7 @@ public class ReportUploaderTest {
 
     @Test
     public void readBody_handlesEmptyStream() throws IOException {
-        InputStream stream = new ByteArrayInputStream(new byte[0]);
-        assertEquals("", ReportUploader.readBody(stream));
+        assertEquals("", ReportUploader.readBody(new ByteArrayInputStream(new byte[0])));
     }
 
     // ---- 3-step upload integration tests ----
@@ -165,41 +114,31 @@ public class ReportUploaderTest {
         server.shutdown();
     }
 
+    private CommitOptions anrOptions() {
+        return new CommitOptions().crashType("Android.ANR").crashTypeId(37);
+    }
+
+    private byte[] sampleZip() throws IOException {
+        return ReportUploader.zip("test.txt", "test content".getBytes(StandardCharsets.UTF_8));
+    }
+
     @Test
     public void upload_performsThreeStepFlow() throws Exception {
         String presignedUrl = server.url("/s3-upload").toString();
 
-        // Step 1: getCrashUploadUrl response
         server.enqueue(new MockResponse()
                 .setResponseCode(200)
                 .setBody("{\"url\": \"" + presignedUrl + "\"}"));
-
-        // Step 2: S3 PUT response
+        server.enqueue(new MockResponse().setResponseCode(200));
         server.enqueue(new MockResponse().setResponseCode(200));
 
-        // Step 3: commitS3CrashUpload response
-        server.enqueue(new MockResponse().setResponseCode(200));
-
-        // Use a ReportUploader that points at our mock server
-        String baseUrl = server.url("").toString();
-        // We need to extract host:port to construct the uploader
-        // The uploader constructs URLs like https://{database}.bugsplat.com/...
-        // So we'll use a TestableReportUploader subclass approach
-        // Actually, let's test the utility methods above and the flow separately
-
-        // For the full flow test, we verify the 3 requests arrive in order
         ReportUploader uploader = new TestableReportUploader("testdb", "testapp", "1.0.0", server);
-        boolean result = uploader.upload(
-                "test content".getBytes(StandardCharsets.UTF_8),
-                "test.txt",
-                "Android.ANR",
-                37
-        );
+        boolean result = uploader.upload(sampleZip(), anrOptions());
 
         assertTrue("upload should succeed", result);
-        assertEquals("should make 3 requests", 3, server.getRequestCount());
+        assertEquals(3, server.getRequestCount());
 
-        // Verify Step 1: getCrashUploadUrl
+        // Step 1
         RecordedRequest req1 = server.takeRequest();
         assertEquals("GET", req1.getMethod());
         assertTrue(req1.getPath().contains("getCrashUploadUrl"));
@@ -207,117 +146,129 @@ public class ReportUploaderTest {
         assertTrue(req1.getPath().contains("appName=testapp"));
         assertTrue(req1.getPath().contains("appVersion=1.0.0"));
 
-        // Verify Step 2: S3 PUT
+        // Step 2
         RecordedRequest req2 = server.takeRequest();
         assertEquals("PUT", req2.getMethod());
         assertEquals("application/octet-stream", req2.getHeader("Content-Type"));
 
-        // Verify the body is a valid zip
-        byte[] putBody = req2.getBody().readByteArray();
-        ZipInputStream zis = new ZipInputStream(new ByteArrayInputStream(putBody));
-        ZipEntry entry = zis.getNextEntry();
-        assertNotNull(entry);
-        assertEquals("test.txt", entry.getName());
-        zis.close();
-
-        // Verify Step 3: commitS3CrashUpload
+        // Step 3
         RecordedRequest req3 = server.takeRequest();
         assertEquals("POST", req3.getMethod());
         assertTrue(req3.getPath().contains("commitS3CrashUpload"));
         String commitBody = req3.getBody().readUtf8();
-        assertTrue("should contain database", commitBody.contains("testdb"));
-        assertTrue("should contain appName", commitBody.contains("testapp"));
-        assertTrue("should contain appVersion", commitBody.contains("1.0.0"));
-        assertTrue("should contain crashType", commitBody.contains("Android.ANR"));
-        assertTrue("should contain crashTypeId", commitBody.contains("37"));
-        assertTrue("should contain md5", commitBody.contains("md5"));
+        assertTrue(commitBody.contains("testdb"));
+        assertTrue(commitBody.contains("testapp"));
+        assertTrue(commitBody.contains("1.0.0"));
+        assertTrue(commitBody.contains("Android.ANR"));
+        assertTrue(commitBody.contains("37"));
+        assertTrue("should use s3Key (capital K)", commitBody.contains("name=\"s3Key\""));
+        assertTrue(commitBody.contains("name=\"md5\""));
     }
 
     @Test
     public void upload_returnsFalseWhenGetUrlFails() throws Exception {
         server.enqueue(new MockResponse().setResponseCode(500));
-
         ReportUploader uploader = new TestableReportUploader("testdb", "testapp", "1.0.0", server);
-        boolean result = uploader.upload(
-                "test".getBytes(StandardCharsets.UTF_8),
-                "test.txt",
-                "Android.ANR",
-                37
-        );
-
-        assertFalse("upload should fail when getCrashUploadUrl fails", result);
+        assertFalse(uploader.upload(sampleZip(), anrOptions()));
         assertEquals(1, server.getRequestCount());
     }
 
     @Test
     public void upload_returnsFalseWhenRateLimited() throws Exception {
         server.enqueue(new MockResponse().setResponseCode(429));
-
         ReportUploader uploader = new TestableReportUploader("testdb", "testapp", "1.0.0", server);
-        boolean result = uploader.upload(
-                "test".getBytes(StandardCharsets.UTF_8),
-                "test.txt",
-                "Android.ANR",
-                37
-        );
-
-        assertFalse("upload should fail when rate limited", result);
+        assertFalse(uploader.upload(sampleZip(), anrOptions()));
     }
 
     @Test
     public void upload_returnsFalseWhenS3PutFails() throws Exception {
         String presignedUrl = server.url("/s3-upload").toString();
-
-        server.enqueue(new MockResponse()
-                .setResponseCode(200)
+        server.enqueue(new MockResponse().setResponseCode(200)
                 .setBody("{\"url\": \"" + presignedUrl + "\"}"));
         server.enqueue(new MockResponse().setResponseCode(403));
 
         ReportUploader uploader = new TestableReportUploader("testdb", "testapp", "1.0.0", server);
-        boolean result = uploader.upload(
-                "test".getBytes(StandardCharsets.UTF_8),
-                "test.txt",
-                "Android.ANR",
-                37
-        );
-
-        assertFalse("upload should fail when S3 PUT fails", result);
+        assertFalse(uploader.upload(sampleZip(), anrOptions()));
         assertEquals(2, server.getRequestCount());
     }
 
     @Test
     public void upload_returnsFalseWhenCommitFails() throws Exception {
         String presignedUrl = server.url("/s3-upload").toString();
-
-        server.enqueue(new MockResponse()
-                .setResponseCode(200)
+        server.enqueue(new MockResponse().setResponseCode(200)
                 .setBody("{\"url\": \"" + presignedUrl + "\"}"));
         server.enqueue(new MockResponse().setResponseCode(200));
         server.enqueue(new MockResponse().setResponseCode(500));
 
         ReportUploader uploader = new TestableReportUploader("testdb", "testapp", "1.0.0", server);
-        boolean result = uploader.upload(
-                "test".getBytes(StandardCharsets.UTF_8),
-                "test.txt",
-                "Android.ANR",
-                37
-        );
-
-        assertFalse("upload should fail when commit fails", result);
+        assertFalse(uploader.upload(sampleZip(), anrOptions()));
         assertEquals(3, server.getRequestCount());
     }
 
+    @Test
+    public void upload_includesAllCommitOptionsFields() throws Exception {
+        String presignedUrl = server.url("/s3-upload").toString();
+        server.enqueue(new MockResponse().setResponseCode(200)
+                .setBody("{\"url\": \"" + presignedUrl + "\"}"));
+        server.enqueue(new MockResponse().setResponseCode(200));
+        server.enqueue(new MockResponse().setResponseCode(200));
+
+        Map<String, String> attrs = new LinkedHashMap<>();
+        attrs.put("env", "prod");
+
+        CommitOptions options = new CommitOptions()
+                .crashType("User.Feedback")
+                .crashTypeId(36)
+                .user("alice")
+                .email("alice@test.com")
+                .appKey("key123")
+                .description("bug desc")
+                .notes("build 42")
+                .attributes(attrs);
+
+        ReportUploader uploader = new TestableReportUploader("testdb", "testapp", "1.0.0", server);
+        assertTrue(uploader.upload(sampleZip(), options));
+
+        server.takeRequest();
+        server.takeRequest();
+        RecordedRequest commitRequest = server.takeRequest();
+        String body = commitRequest.getBody().readUtf8();
+
+        assertTrue(body.contains("name=\"user\""));
+        assertTrue(body.contains("alice"));
+        assertTrue(body.contains("name=\"email\""));
+        assertTrue(body.contains("alice@test.com"));
+        assertTrue(body.contains("name=\"appKey\""));
+        assertTrue(body.contains("key123"));
+        assertTrue(body.contains("name=\"description\""));
+        assertTrue(body.contains("bug desc"));
+        assertTrue(body.contains("name=\"notes\""));
+        assertTrue(body.contains("build 42"));
+        assertTrue(body.contains("name=\"attributes\""));
+        assertTrue("attributes should be JSON-encoded", body.contains("\"env\":\"prod\""));
+    }
+
+    @Test
+    public void upload_rejectsEmptyPayload() throws Exception {
+        ReportUploader uploader = new TestableReportUploader("testdb", "testapp", "1.0.0", server);
+        try {
+            uploader.upload(new byte[0], anrOptions());
+            fail("expected IllegalArgumentException");
+        } catch (IllegalArgumentException expected) {
+            // expected
+        }
+    }
+
     /**
-     * Test subclass that routes all HTTP calls to the MockWebServer
-     * instead of the real BugSplat API.
+     * Test subclass that routes all HTTP calls to the MockWebServer.
      */
     static class TestableReportUploader extends ReportUploader {
         private final String baseUrl;
 
         TestableReportUploader(String database, String application, String version, MockWebServer server) {
             super(database, application, version);
-            // MockWebServer URLs include a trailing slash; strip it since
-            // ReportUploader appends paths starting with "/".
+            // MockWebServer's server.url("").toString() ends with a "/"; strip
+            // it so URL joining in ReportUploader produces clean paths.
             String url = server.url("").toString();
             this.baseUrl = url.endsWith("/") ? url.substring(0, url.length() - 1) : url;
         }

--- a/app/src/test/java/com/bugsplat/android/ReportUploaderTest.java
+++ b/app/src/test/java/com/bugsplat/android/ReportUploaderTest.java
@@ -192,7 +192,7 @@ public class ReportUploaderTest {
         boolean result = uploader.upload(
                 "test content".getBytes(StandardCharsets.UTF_8),
                 "test.txt",
-                "Android ANR",
+                "Android.ANR",
                 37
         );
 
@@ -228,7 +228,7 @@ public class ReportUploaderTest {
         assertTrue("should contain database", commitBody.contains("testdb"));
         assertTrue("should contain appName", commitBody.contains("testapp"));
         assertTrue("should contain appVersion", commitBody.contains("1.0.0"));
-        assertTrue("should contain crashType", commitBody.contains("Android ANR"));
+        assertTrue("should contain crashType", commitBody.contains("Android.ANR"));
         assertTrue("should contain crashTypeId", commitBody.contains("37"));
         assertTrue("should contain md5", commitBody.contains("md5"));
     }
@@ -241,7 +241,7 @@ public class ReportUploaderTest {
         boolean result = uploader.upload(
                 "test".getBytes(StandardCharsets.UTF_8),
                 "test.txt",
-                "Android ANR",
+                "Android.ANR",
                 37
         );
 
@@ -257,7 +257,7 @@ public class ReportUploaderTest {
         boolean result = uploader.upload(
                 "test".getBytes(StandardCharsets.UTF_8),
                 "test.txt",
-                "Android ANR",
+                "Android.ANR",
                 37
         );
 
@@ -277,7 +277,7 @@ public class ReportUploaderTest {
         boolean result = uploader.upload(
                 "test".getBytes(StandardCharsets.UTF_8),
                 "test.txt",
-                "Android ANR",
+                "Android.ANR",
                 37
         );
 
@@ -299,7 +299,7 @@ public class ReportUploaderTest {
         boolean result = uploader.upload(
                 "test".getBytes(StandardCharsets.UTF_8),
                 "test.txt",
-                "Android ANR",
+                "Android.ANR",
                 37
         );
 

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -13,10 +13,16 @@ if (localPropsFile.exists()) {
     localPropsFile.withInputStream { localProps.load(it) }
 }
 
-def bugsplatDb = localProps.getProperty('bugsplat.database')
+// Resolution order: local.properties → -Pbugsplat.database=... → BUGSPLAT_DATABASE env var
+def bugsplatDb = localProps.getProperty('bugsplat.database') ?:
+                 project.findProperty('bugsplat.database') ?:
+                 System.getenv('BUGSPLAT_DATABASE')
 if (!bugsplatDb) {
     throw new GradleException(
-        "bugsplat.database is not configured. Add bugsplat.database=yourdb to local.properties"
+        "bugsplat.database is not configured. Set it in one of:\n" +
+        "  - local.properties: bugsplat.database=yourdb\n" +
+        "  - gradle property:  -Pbugsplat.database=yourdb\n" +
+        "  - env var:          BUGSPLAT_DATABASE=yourdb"
     )
 }
 

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -2,14 +2,31 @@ plugins {
     id 'com.android.application'
 }
 
-// BugSplat configuration - Define at the top level so it can be used throughout the build file
+// Load BugSplat credentials from local.properties (gitignored).
+// Required for symbol upload - add the following to local.properties:
+//   bugsplat.database=yourdb
+//   bugsplat.clientId=yourClientId
+//   bugsplat.clientSecret=yourClientSecret
+def localProps = new Properties()
+def localPropsFile = rootProject.file('local.properties')
+if (localPropsFile.exists()) {
+    localPropsFile.withInputStream { localProps.load(it) }
+}
+
+def bugsplatDb = localProps.getProperty('bugsplat.database')
+if (!bugsplatDb) {
+    throw new GradleException(
+        "bugsplat.database is not configured. Add bugsplat.database=yourdb to local.properties"
+    )
+}
+
+// BugSplat configuration - appName and appVersion are derived from android.defaultConfig below.
 ext {
-    bugsplatDatabase = "fred" // Replace with your BugSplat database name
-    bugsplatAppName = "my-android-crasher" // Replace with your application name
-    bugsplatAppVersion = "1.0.0" // Can be overridden by versionName below
-    // Optional: Add your BugSplat API credentials for symbol upload
-    bugsplatClientId = ""     // Replace with your BugSplat API client ID (optional)
-    bugsplatClientSecret = "" // Replace with your BugSplat API client secret (optional)
+    bugsplatDatabase = bugsplatDb
+    bugsplatAppName = null       // populated from android.defaultConfig.applicationId
+    bugsplatAppVersion = null    // populated from android.defaultConfig.versionName
+    bugsplatClientId = localProps.getProperty('bugsplat.clientId', '')
+    bugsplatClientSecret = localProps.getProperty('bugsplat.clientSecret', '')
 }
 
 android {
@@ -29,17 +46,17 @@ android {
         versionName "1.0.0"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
-        
+
         // Match the ABI filters from the library
         ndk {
             abiFilters 'arm64-v8a', 'x86_64', 'armeabi-v7a'
         }
-        
-        // Update BugSplat version to match app version if needed
-        if (project.ext.bugsplatAppVersion != versionName) {
-            project.ext.bugsplatAppVersion = versionName
-        }
-        
+
+        // Use applicationId and versionName as the single source of truth for
+        // BugSplat's appName/appVersion so they stay in sync with the build.
+        project.ext.bugsplatAppName = applicationId
+        project.ext.bugsplatAppVersion = versionName
+
         // Add BugSplat configuration to BuildConfig
         buildConfigField "String", "BUGSPLAT_DATABASE", "\"${project.ext.bugsplatDatabase}\""
         buildConfigField "String", "BUGSPLAT_APP_NAME", "\"${project.ext.bugsplatAppName}\""

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -315,6 +315,9 @@ def abiFilters = android.defaultConfig.ndk.abiFilters
 buildTypes.each { buildType ->
     abiFilters.each { abi ->
         tasks.register("uploadBugSplatSymbols${buildType.capitalize()}${abi.capitalize()}") {
+            // Ensure native libraries are merged before we try to upload symbols.
+            // merge${BuildType}NativeLibs produces merged_native_libs/<buildType>/out/lib/<abi>/
+            dependsOn "merge${buildType.capitalize()}NativeLibs"
             dependsOn uploadBugSplatSymbols
             doFirst {
                 System.setProperty("buildType", buildType)

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -163,149 +163,95 @@ task downloadSymbolUpload {
     }
 }
 
-// Task to upload debug symbols for native libraries
-task uploadBugSplatSymbols {
-    doLast {
-        // Check if client credentials are provided
-        if (!project.ext.has('bugsplatClientId') || !project.ext.bugsplatClientId || 
-            !project.ext.has('bugsplatClientSecret') || !project.ext.bugsplatClientSecret) {
-            logger.warn("BugSplat API client credentials (clientId and clientSecret) are not provided.")
-            logger.warn("Symbol upload requires authentication. Please add the following to your build.gradle:")
-            logger.warn("ext {")
-            logger.warn("    bugsplatClientId = \"your_client_id\"")
-            logger.warn("    bugsplatClientSecret = \"your_client_secret\"")
-            logger.warn("}")
-            logger.warn("You can obtain these credentials from your BugSplat account.")
-            logger.warn("Skipping symbol upload.")
-            return
-        }
-        
-        // Get the current build variant and ABI
-        def buildType = System.getProperty("buildType") ?: "debug" // Default to debug if not specified
-        def currentAbi = System.getProperty("abi") ?: "arm64-v8a" // Default to arm64-v8a if not specified
-        
-        logger.lifecycle("Uploading symbols for build type: ${buildType}, ABI: ${currentAbi}")
-        
-        // Path to the merged native libraries for the current build type.
-        // AGP 8.6+ includes the producing task name in the intermediate path.
-        def mergeTaskName = "merge${buildType.capitalize()}NativeLibs"
-        def nativeLibsDir = "${buildDir}/intermediates/merged_native_libs/${buildType}/${mergeTaskName}/out/lib/${currentAbi}"
+// Resolve the symbol-upload executable for the current OS, downloading it if needed.
+// Returns the File, or null if download fails / OS unsupported.
+def resolveSymbolUploadExecutable = {
+    def osName = System.getProperty("os.name").toLowerCase()
+    def executableName
+    def downloadUrl
+    if (osName.contains("windows")) {
+        executableName = "symbol-upload-windows.exe"
+        downloadUrl = "https://app.bugsplat.com/download/symbol-upload-windows.exe"
+    } else if (osName.contains("mac")) {
+        executableName = "symbol-upload-macos"
+        downloadUrl = "https://app.bugsplat.com/download/symbol-upload-macos"
+    } else if (osName.contains("linux")) {
+        executableName = "symbol-upload-linux"
+        downloadUrl = "https://app.bugsplat.com/download/symbol-upload-linux"
+    } else {
+        logger.error("Unsupported operating system for symbol-upload: ${osName}")
+        return null
+    }
 
-        // Check if the directory exists
-        def nativeLibsDirFile = file(nativeLibsDir)
-        if (!nativeLibsDirFile.exists()) {
-            logger.warn("Native libraries directory not found: ${nativeLibsDir}")
-            logger.warn("Skipping symbol upload")
-            return
-        }
-        
-        // Download the symbol-upload executable if needed
-        def isWindows = System.getProperty("os.name").toLowerCase().contains("windows")
-        def isMac = System.getProperty("os.name").toLowerCase().contains("mac")
-        def isLinux = System.getProperty("os.name").toLowerCase().contains("linux")
-        
-        def downloadUrl
-        def executableName
-        def executableFile
-        
-        if (isWindows) {
-            downloadUrl = "https://app.bugsplat.com/download/symbol-upload-windows.exe"
-            executableName = "symbol-upload-windows.exe"
-            executableFile = file("${rootProject.projectDir}/${executableName}")
-        } else if (isMac) {
-            downloadUrl = "https://app.bugsplat.com/download/symbol-upload-macos"
-            executableName = "symbol-upload-macos"
-            executableFile = file("${rootProject.projectDir}/${executableName}")
-        } else if (isLinux) {
-            downloadUrl = "https://app.bugsplat.com/download/symbol-upload-linux"
-            executableName = "symbol-upload-linux"
-            executableFile = file("${rootProject.projectDir}/${executableName}")
-        } else {
-            logger.error("Unsupported operating system for symbol-upload")
-            logger.error("Skipping symbol upload")
-            return
-        }
-        
-        // Check if the executable already exists
-        if (!executableFile.exists()) {
-            // Download the executable
-            logger.lifecycle("Downloading symbol upload executable from: ${downloadUrl}")
-            
-            try {
-                // Create a new URL and connection
-                def url = new URL(downloadUrl)
-                def connection = url.openConnection()
-                connection.setRequestProperty("User-Agent", "BugSplat-Android-Gradle-Plugin")
-                
-                // Download the file
-                executableFile.withOutputStream { outputStream ->
-                    connection.inputStream.with { inputStream ->
-                        outputStream << inputStream
-                    }
-                }
-                
-                // Make the file executable (not needed for Windows)
-                if (!isWindows) {
-                    executableFile.setExecutable(true)
-                    logger.lifecycle("Made ${executableFile.absolutePath} executable")
-                }
-                
-                logger.lifecycle("Downloaded symbol upload executable to: ${executableFile.absolutePath}")
-            } catch (Exception e) {
-                logger.error("Failed to download symbol-upload executable: ${e.message}")
-                logger.error("Skipping symbol upload")
-                return
+    def executableFile = file("${rootProject.projectDir}/${executableName}")
+    if (!executableFile.exists()) {
+        logger.lifecycle("Downloading symbol-upload executable from: ${downloadUrl}")
+        try {
+            def connection = new URL(downloadUrl).openConnection()
+            connection.setRequestProperty("User-Agent", "BugSplat-Android-Gradle-Plugin")
+            executableFile.withOutputStream { outStream ->
+                connection.inputStream.with { inStream -> outStream << inStream }
             }
-        } else {
-            logger.lifecycle("Symbol upload executable already exists at: ${executableFile.absolutePath}")
-        }
-        
-        // Path to the symbol-upload executable
-        def symbolUploadPath = executableFile.absolutePath
-        
-        logger.lifecycle("Uploading symbols from directory: ${nativeLibsDir}")
-        
-        // Build the command with the directory and glob pattern
-        def command = [
-            symbolUploadPath,
-            "-b", project.ext.bugsplatDatabase,
-            "-a", project.ext.bugsplatAppName,
-            "-v", project.ext.bugsplatAppVersion,
-            "-d", nativeLibsDirFile.absolutePath,
-            "-f", "*.so", // Only match .so files directly in the ABI directory
-            "-m",  // Enable multi-threading
-            "-i", project.ext.bugsplatClientId,
-            "-s", project.ext.bugsplatClientSecret
-        ]
-        
-        // Execute the command
-        logger.lifecycle("Executing command: ${command.join(' ')}")
-        def process = command.execute()
-        def output = new StringBuilder()
-        def error = new StringBuilder()
-        
-        // Capture and log output in real-time
-        process.consumeProcessOutput(
-            { line -> 
-                output.append(line).append('\n')
-                logger.lifecycle("symbol-upload: ${line}")
-            } as Appendable,
-            { line -> 
-                error.append(line).append('\n')
-                logger.error("symbol-upload error: ${line}")
-            } as Appendable
-        )
-        
-        process.waitFor()
-        
-        if (process.exitValue() == 0) {
-            logger.lifecycle("Successfully uploaded symbols for ${buildType}/${currentAbi}")
-        } else {
-            logger.error("Failed to upload symbols, exit code: ${process.exitValue()}")
-            if (error.length() > 0) {
-                logger.error("Error output: ${error}")
+            if (!osName.contains("windows")) {
+                executableFile.setExecutable(true)
             }
+            logger.lifecycle("Downloaded symbol-upload executable to: ${executableFile.absolutePath}")
+        } catch (Exception e) {
+            logger.error("Failed to download symbol-upload executable: ${e.message}")
+            return null
         }
+    }
+    return executableFile
+}
+
+// Upload symbols for a single buildType + abi. Runs synchronously.
+def uploadSymbolsForAbi = { String buildType, String abi ->
+    // Check if client credentials are provided
+    if (!project.ext.bugsplatClientId || !project.ext.bugsplatClientSecret) {
+        logger.warn("BugSplat API client credentials are not configured.")
+        logger.warn("Add bugsplat.clientId and bugsplat.clientSecret to local.properties to enable symbol upload.")
+        logger.warn("Skipping symbol upload.")
+        return
+    }
+
+    // AGP 8.6+ includes the producing task name in the intermediate path.
+    def mergeTaskName = "merge${buildType.capitalize()}NativeLibs"
+    def nativeLibsDir = file("${buildDir}/intermediates/merged_native_libs/${buildType}/${mergeTaskName}/out/lib/${abi}")
+    if (!nativeLibsDir.exists()) {
+        logger.warn("Native libs not found for ${buildType}/${abi}: ${nativeLibsDir}")
+        logger.warn("(ABI likely wasn't built for the current target device). Skipping symbol upload.")
+        return
+    }
+
+    def executable = resolveSymbolUploadExecutable()
+    if (executable == null) {
+        return
+    }
+
+    logger.lifecycle("Uploading symbols for ${buildType}/${abi} from ${nativeLibsDir}")
+    def command = [
+        executable.absolutePath,
+        "-b", project.ext.bugsplatDatabase,
+        "-a", project.ext.bugsplatAppName,
+        "-v", project.ext.bugsplatAppVersion,
+        "-d", nativeLibsDir.absolutePath,
+        "-f", "*.so",
+        "-m",
+        "-i", project.ext.bugsplatClientId,
+        "-s", project.ext.bugsplatClientSecret
+    ]
+
+    def process = command.execute()
+    process.consumeProcessOutput(
+        { line -> logger.lifecycle("symbol-upload: ${line}") } as Appendable,
+        { line -> logger.error("symbol-upload error: ${line}") } as Appendable
+    )
+    process.waitFor()
+
+    if (process.exitValue() == 0) {
+        logger.lifecycle("Successfully uploaded symbols for ${buildType}/${abi}")
+    } else {
+        logger.error("Failed to upload symbols for ${buildType}/${abi}, exit code: ${process.exitValue()}")
     }
 }
 
@@ -313,26 +259,28 @@ task uploadBugSplatSymbols {
 def buildTypes = ['debug', 'release']
 def abiFilters = android.defaultConfig.ndk.abiFilters
 
-// Create tasks for each build type and ABI combination
+// Register per-ABI upload tasks. Each task has its own body (no shared task)
+// so AllAbis can serialize them via mustRunAfter — the symbol-upload binary
+// uses a shared temp dir, so parallel invocations are not safe.
 buildTypes.each { buildType ->
-    abiFilters.each { abi ->
+    def perAbiTasks = abiFilters.collect { abi ->
         tasks.register("uploadBugSplatSymbols${buildType.capitalize()}${abi.capitalize()}") {
-            // Ensure native libraries are merged before we try to upload symbols.
-            // merge${BuildType}NativeLibs produces merged_native_libs/<buildType>/out/lib/<abi>/
             dependsOn "merge${buildType.capitalize()}NativeLibs"
-            dependsOn uploadBugSplatSymbols
-            doFirst {
-                System.setProperty("buildType", buildType)
-                System.setProperty("abi", abi)
+            doLast {
+                uploadSymbolsForAbi(buildType, abi)
             }
         }
     }
-    
-    // Create a task to upload symbols for all ABIs for this build type
-    tasks.register("uploadBugSplatSymbols${buildType.capitalize()}AllAbis") {
-        dependsOn abiFilters.collect { abi ->
-            tasks.named("uploadBugSplatSymbols${buildType.capitalize()}${abi.capitalize()}")
+
+    // Chain the per-ABI tasks so they run serially when AllAbis is invoked.
+    perAbiTasks.eachWithIndex { taskProvider, i ->
+        if (i > 0) {
+            taskProvider.configure { mustRunAfter perAbiTasks[i - 1] }
         }
+    }
+
+    tasks.register("uploadBugSplatSymbols${buildType.capitalize()}AllAbis") {
+        dependsOn perAbiTasks
     }
 }
 

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -186,9 +186,11 @@ task uploadBugSplatSymbols {
         
         logger.lifecycle("Uploading symbols for build type: ${buildType}, ABI: ${currentAbi}")
         
-        // Path to the merged native libraries for the current build type
-        def nativeLibsDir = "${buildDir}/intermediates/merged_native_libs/${buildType}/out/lib/${currentAbi}"
-        
+        // Path to the merged native libraries for the current build type.
+        // AGP 8.6+ includes the producing task name in the intermediate path.
+        def mergeTaskName = "merge${buildType.capitalize()}NativeLibs"
+        def nativeLibsDir = "${buildDir}/intermediates/merged_native_libs/${buildType}/${mergeTaskName}/out/lib/${currentAbi}"
+
         // Check if the directory exists
         def nativeLibsDirFile = file(nativeLibsDir)
         if (!nativeLibsDirFile.exists()) {

--- a/example/src/main/java/com/bugsplat/example/MainActivity.java
+++ b/example/src/main/java/com/bugsplat/example/MainActivity.java
@@ -74,15 +74,18 @@ public class MainActivity extends AppCompatActivity {
         anrButton.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                Log.d(TAG, "Triggering ANR by blocking main thread for ~10 seconds...");
-                statusTextView.setText("Status: Blocking main thread (ANR will trigger after ~5s)...");
-                // Block the main thread long enough to trigger a system ANR dialog
-                try {
-                    Thread.sleep(10_000);
-                } catch (InterruptedException e) {
-                    Thread.currentThread().interrupt();
+                Log.d(TAG, "Triggering ANR by blocking main thread...");
+                Toast.makeText(MainActivity.this,
+                        "Tap the screen to trigger the ANR dialog", Toast.LENGTH_SHORT).show();
+                // Infinite loop blocks the main thread permanently.
+                // The system will show an ANR dialog when the next input event
+                // can't be dispatched within ~5s. Dismissing with "Close app"
+                // kills the process, and the ANR is captured via
+                // ApplicationExitInfo on next launch.
+                //noinspection InfiniteLoopStatement
+                while (true) {
+                    Thread.yield();
                 }
-                statusTextView.setText("Status: Main thread unblocked");
             }
         });
 

--- a/example/src/main/java/com/bugsplat/example/MainActivity.java
+++ b/example/src/main/java/com/bugsplat/example/MainActivity.java
@@ -28,6 +28,7 @@ public class MainActivity extends AppCompatActivity {
     private static final String TAG = "BugSplatExample";
     private TextView statusTextView;
     private Button crashButton;
+    private Button anrButton;
     private Button feedbackButton;
     private Button setAttributeButton;
 
@@ -39,6 +40,7 @@ public class MainActivity extends AppCompatActivity {
         // Initialize views
         statusTextView = findViewById(R.id.statusTextView);
         crashButton = findViewById(R.id.crashButton);
+        anrButton = findViewById(R.id.anrButton);
         feedbackButton = findViewById(R.id.feedbackButton);
         setAttributeButton = findViewById(R.id.setAttributeButton);
 
@@ -65,6 +67,22 @@ public class MainActivity extends AppCompatActivity {
                     statusTextView.setText("Error: " + e.getMessage());
                     Toast.makeText(MainActivity.this, "Error: " + e.getMessage(), Toast.LENGTH_LONG).show();
                 }
+            }
+        });
+
+        // Set up click listener for ANR button
+        anrButton.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                Log.d(TAG, "Triggering ANR by blocking main thread for ~10 seconds...");
+                statusTextView.setText("Status: Blocking main thread (ANR will trigger after ~5s)...");
+                // Block the main thread long enough to trigger a system ANR dialog
+                try {
+                    Thread.sleep(10_000);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+                statusTextView.setText("Status: Main thread unblocked");
             }
         });
 

--- a/example/src/main/java/com/bugsplat/example/MainActivity.java
+++ b/example/src/main/java/com/bugsplat/example/MainActivity.java
@@ -74,18 +74,15 @@ public class MainActivity extends AppCompatActivity {
         anrButton.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                Log.d(TAG, "Triggering ANR by blocking main thread...");
+                Log.d(TAG, "Triggering ANR via native hang...");
                 Toast.makeText(MainActivity.this,
                         "Tap the screen to trigger the ANR dialog", Toast.LENGTH_SHORT).show();
-                // Infinite loop blocks the main thread permanently.
-                // The system will show an ANR dialog when the next input event
-                // can't be dispatched within ~5s. Dismissing with "Close app"
-                // kills the process, and the ANR is captured via
-                // ApplicationExitInfo on next launch.
-                //noinspection InfiniteLoopStatement
-                while (true) {
-                    Thread.yield();
-                }
+                // BugSplat.hang() blocks the main thread in a native infinite loop,
+                // so the resulting ANR thread dump includes a symbolicated C++ frame.
+                // Tap the screen to trigger the ANR dialog, then choose "Close app"
+                // to kill the process. The ANR will be captured via ApplicationExitInfo
+                // and uploaded on next launch.
+                BugSplat.hang();
             }
         });
 

--- a/example/src/main/res/layout/activity_main.xml
+++ b/example/src/main/res/layout/activity_main.xml
@@ -50,7 +50,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginTop="16dp"
-        android:text="Trigger ANR"
+        android:text="@string/anr_button"
         style="@style/Widget.BugSplat.Button.Crash"
         app:layout_constraintBottom_toTopOf="@+id/feedbackButton"
         app:layout_constraintEnd_toEndOf="parent"

--- a/example/src/main/res/layout/activity_main.xml
+++ b/example/src/main/res/layout/activity_main.xml
@@ -40,10 +40,22 @@
         android:layout_marginTop="32dp"
         android:text="@string/crash_button"
         style="@style/Widget.BugSplat.Button.Crash"
-        app:layout_constraintBottom_toTopOf="@+id/feedbackButton"
+        app:layout_constraintBottom_toTopOf="@+id/anrButton"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/titleTextView" />
+
+    <Button
+        android:id="@+id/anrButton"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:text="Trigger ANR"
+        style="@style/Widget.BugSplat.Button.Crash"
+        app:layout_constraintBottom_toTopOf="@+id/feedbackButton"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/crashButton" />
 
     <Button
         android:id="@+id/feedbackButton"
@@ -55,7 +67,7 @@
         app:layout_constraintBottom_toTopOf="@+id/setAttributeButton"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/crashButton" />
+        app:layout_constraintTop_toBottomOf="@+id/anrButton" />
 
     <Button
         android:id="@+id/setAttributeButton"

--- a/example/src/main/res/values/strings.xml
+++ b/example/src/main/res/values/strings.xml
@@ -1,6 +1,7 @@
 <resources>
     <string name="app_name">BugSplat Example</string>
     <string name="crash_button">Crash App</string>
+    <string name="anr_button">Trigger ANR</string>
     <string name="feedback_button">Send Feedback</string>
     <string name="set_attribute_button">Set Attribute</string>
 </resources> 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,6 +5,7 @@ coreKtx = "1.15.0"
 junit = "4.13.2"
 junitVersion = "1.2.1"
 espressoCore = "3.6.1"
+mockwebserver = "4.12.0"
 appcompat = "1.7.0"
 material = "1.10.0"
 constraintlayout = "2.2.0"
@@ -15,6 +16,7 @@ androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = 
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }
 androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }
+mockwebserver = { group = "com.squareup.okhttp3", name = "mockwebserver", version.ref = "mockwebserver" }
 androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "appcompat" }
 material = { group = "com.google.android.material", name = "material", version.ref = "material" }
 androidx-constraintlayout = { group = "androidx.constraintlayout", name = "constraintlayout", version.ref = "constraintlayout" }


### PR DESCRIPTION
## Summary

- **ANR detection** via `ApplicationExitInfo` API on Android 11+ (API 30+). On each SDK init, checks for unreported ANR exit reasons from previous sessions, reads the system thread dump, and uploads it to BugSplat. Thread dumps include full Java + native stacks with BuildIds for symbolication against .sym files.
- **3-part S3 upload** (`ReportUploader`) replacing direct multipart POSTs: `getCrashUploadUrl` → PUT to presigned S3 URL → `commitS3CrashUpload`. Used by both `AnrReporter` (crashTypeId=37) and `FeedbackClient` (crashTypeId=36).
- **Unit tests** — 21 tests covering `ReportUploader` (zip creation, MD5, HTTP flow with MockWebServer) and `FeedbackClient` (report formatting, field handling, crash type).
- **CI workflow** — GitHub Actions runs unit tests on PRs to main.

## Test plan

- [x] Verify ANR detection on Android 11+ device: trigger ANR, relaunch app, confirm upload
- [x] Verify feedback upload still works via example app
- [x] Verify CI workflow runs tests on this PR
- [x] Confirm `./gradlew :app:testDebugUnitTest` passes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)