### PR TITLE
chore(app): remove dead copySymbolUploadBinary task

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -123,37 +123,6 @@ dependencies {
     androidTestImplementation libs.androidx.espresso.core
 }
 
-// Create assets directory if it doesn't exist
-task createAssetsDirectory {
-    doLast {
-        def assetsDir = file('src/main/assets')
-        if (!assetsDir.exists()) {
-            assetsDir.mkdirs()
-        }
-    }
-}
-
-// Copy symbol-upload binary to assets directory
-// This assumes the symbol-upload binary is in the project root directory
-// Adjust the path as needed
-task copySymbolUploadBinary(dependsOn: createAssetsDirectory) {
-    doLast {
-        def symbolUploadBinary = file('../symbol-upload')
-        if (symbolUploadBinary.exists()) {
-            copy {
-                from symbolUploadBinary
-                into 'src/main/assets'
-            }
-        } else {
-            logger.warn("symbol-upload binary not found at ${symbolUploadBinary.absolutePath}")
-            logger.warn("Please place the symbol-upload binary in the project root directory or adjust the path in build.gradle")
-        }
-    }
-}
-
-// Run the copy task before the preBuild task
-preBuild.dependsOn copySymbolUploadBinary
-
 afterEvaluate {
     android.libraryVariants.all { variant ->
         def bundleTask = tasks.named("bundle${variant.name.capitalize()}Aar")


### PR DESCRIPTION
## What

Removes the `copySymbolUploadBinary` task (and the now-orphaned `createAssetsDirectory` it depended on) from `app/build.gradle`.

## Why

The task looked for `../symbol-upload` — a name the binary never has (it's `symbol-upload-macos` / `-linux` / `-windows.exe`) — so it silently did nothing on every build, just logging a "not found" warning. Making the path "work" would have packaged the ~125 MB desktop CLI into the published AAR, so the task is removed rather than fixed.

Pure dead-code cleanup; no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)